### PR TITLE
ButtonInput scan period lowered, Event broadcast const ref usage

### DIFF
--- a/src/Event/Event.h
+++ b/src/Event/Event.h
@@ -135,7 +135,7 @@ protected:
 
 		bool succeeded = true;
 
-		for(HandleContainer container : handles){
+		for(const HandleContainer& container : handles){
 			if(container.handle == nullptr || !container.owningObject.isValid()){
 				continue;
 			}

--- a/src/Services/ButtonInput.h
+++ b/src/Services/ButtonInput.h
@@ -37,7 +37,7 @@ private:
 
 	std::unordered_map<int, bool> btnState;
 	std::unordered_map<int, uint64_t> dbTime;
-	static constexpr uint64_t SleepTime = 30; // [ms]
+	static constexpr uint64_t SleepTime = 5; // [ms]
 	static constexpr uint64_t DebounceTime = 5; // [ms]
 };
 


### PR DESCRIPTION
Input lag je prejak s tvojim periodom.

Mjerilo kvalitete je responsivness boost touch slidera i njegovih ledica.
Možeš probati s branchom https://github.com/CircuitMess/Nevera-Controller/tree/TouchInput-NEV-21

Test kod (na kraju maina):

		buttonInput->OnButtonEvent.bind(this, [ledService](Enum<int> btn, ButtonInput::Action action){
			switch(btn){
				case Button::Slider0:
					ledService->on(LEDs::Slider0, action == ButtonInput::Action::Press ? 0.1f : 0);
					break;
				case Button::Slider1:
					ledService->on(LEDs::Slider1, action == ButtonInput::Action::Press ? 0.1f : 0);
					break;
				case Button::Slider2:
					ledService->on(LEDs::Slider2, action == ButtonInput::Action::Press ? 0.1f : 0);
					break;
				case Button::Slider3:
					ledService->on(LEDs::Slider3, action == ButtonInput::Action::Press ? 0.1f : 0);
					break;

				case Button::Slider4:
					ledService->on(LEDs::Slider4, action == ButtonInput::Action::Press ? 0.1f : 0);
					break;
			}
			printf("Button %d %s\n", (int) btn, action == ButtonInput::Action::Press ? "pressed" : "released");
		});