### PR TITLE
Class and SubclassOf constexpr support (BUT-100)

### DIFF
--- a/src/Misc/TemplateTypes.h
+++ b/src/Misc/TemplateTypes.h
@@ -4,6 +4,8 @@
 #include <source_location>
 #include <string>
 #include <vector>
+#include <cinttypes>
+#include "Djb.h"
 
 template<typename... Args>
 class TemplateTypesInfo {
@@ -38,7 +40,7 @@ public:
 
             constexpr static size_t MagicHashNumber = 3; // This is the max number of hashes that can fit into a 32 character string by appending, that is then used to calculate a new hash.
             for(size_t i = 0; i < std::min(hashes.size(), static_cast<size_t>(MagicHashNumber)); ++i) {
-                newHashStr += std::to_string(hashes[i]);
+                newHashStr += __constexpr_to_string(hashes[i]);
             }
 
             hashes.erase(hashes.begin(), hashes.begin() + std::min(hashes.size(), static_cast<size_t>(MagicHashNumber)));
@@ -53,6 +55,25 @@ private:
      * @brief Default constructor is deleted to prevent creating instances of this purely static class.
      */
     TemplateTypesInfo() = delete;
+
+    /**
+     * @brief Constexpr replacement for std::to_string(uint32_t), which is not constexpr in C++23.
+     * Used so that TypesHash can be evaluated at compile time, allowing GENERATED_BODY to produce a
+     * constexpr static class instance for templated Object subclasses.
+     */
+    static constexpr std::string __constexpr_to_string(uint32_t value) {
+        if(value == 0) {
+            return "0";
+        }
+
+        std::string result;
+        while(value > 0) {
+            result.insert(result.begin(), static_cast<char>('0' + (value % 10)));
+            value /= 10;
+        }
+
+        return result;
+    }
 };
 
 #endif //TEMPLATETYPES_H

--- a/src/Object/Class.cpp
+++ b/src/Object/Class.cpp
@@ -18,26 +18,6 @@ void ClassRegistry::registerClass(const Class* cls) noexcept{
 	classes[cls->getID()] = cls;
 }
 
-uint64_t Class::getID() const noexcept{
-	return classID;
-}
-
-bool Class::isA(const Class *other) const noexcept {
-	if(other == nullptr) {
-		return false;
-	}
-
-	return other->getID() == getID();
-}
-
-Class::Class(uint64_t ID) noexcept : classID(ID) {
-	if(registry == nullptr){
-		registry = new ClassRegistry();
-	}
-
-	registry->registerClass(this);
-}
-
 StrongObjectPtr<Object> Class::__createObject(void* arguments) const noexcept {
 	void* temp = operator new(sizeof(Object));
 	if(temp == nullptr){

--- a/src/Object/Class.h
+++ b/src/Object/Class.h
@@ -4,7 +4,13 @@
 #include <cinttypes>
 #include <map>
 #include <string>
-#include <Object/Object.h>
+#include <tuple>
+#include <type_traits>
+#include "Memory/SmartPtr/StrongObjectPtr.h"
+#include "ObjectConstruct.h"
+
+class Object;
+class Class;
 
 /**
  * @brief Class registry is used internally by CMF to track all existing object classes by their ID.
@@ -12,7 +18,7 @@
 class ClassRegistry {
 public:
 	/**
-	 * @brief Deleted default constructor.
+	 * @brief Default destructor.
 	 */
 	virtual ~ClassRegistry() noexcept = default;
 
@@ -20,12 +26,12 @@ public:
 	 * @param ID ID of the wanted class.
 	 * @return The class matching the given ID. If no class matches it, returns nullptr.
 	 */
-	const class Class* getClass(uint64_t ID) const noexcept;
+	const Class* getClass(uint64_t ID) const noexcept;
 
 	/**
-	 * @brief Registers a class, called by each class when constructed.
-	 * Each class is constructed only once statically for each Object type.
-	 * @param cls 
+	 * @brief Registers a class. Each class is registered only once at static initialization time
+	 * via a ClassRegistrar helper instance.
+	 * @param cls
 	 */
 	void registerClass(const Class* cls) noexcept;
 
@@ -40,12 +46,21 @@ private:
  */
 class Class {
 	friend class Object;
+	friend class ClassRegistrar;
 
 public:
 	/**
-	 * @brief Default destructor.
+	 * @brief Constructor of the class with given ID. The constructor is constexpr so that
+	 * Class instances can be used as static constexpr values, allowing constexpr SubclassOf usage.
+	 * The ID is generated partially at compile time, and partially at the beginning of the runtime statically.
+	 * @param ID The generated ID of the class.
 	 */
-	virtual ~Class() = default;
+	constexpr explicit Class(uint64_t ID) noexcept : classID(ID) {}
+
+	/**
+	 * @brief Default constexpr destructor.
+	 */
+	constexpr virtual ~Class() noexcept = default;
 
 	/**
 	 * @return An object represented by this class.
@@ -60,7 +75,9 @@ public:
 	 * @return The ID of the class. Each class has a unique ID
 	 * depending on the name of the object it represents and the templates types of that object.
 	 */
-	uint64_t getID() const noexcept;
+	constexpr uint64_t getID() const noexcept {
+		return classID;
+	}
 
 	/**
 	 * @tparam Type The type of interface that the object represented by this class implements.
@@ -76,7 +93,13 @@ public:
 	 * @param other The type class being compared to.
 	 * @return True if same type or derived from it, false otherwise.
 	 */
-	virtual bool isA(const Class* other) const noexcept;
+	constexpr virtual bool isA(const Class* other) const noexcept {
+		if(other == nullptr) {
+			return false;
+		}
+
+		return other->getID() == getID();
+	}
 
 	/**
 	 * @brief Checks if this class is of type given in the template, or derived from it.
@@ -84,7 +107,7 @@ public:
 	 * @return True if same type or derived from it, false otherwise.
 	 */
 	template<typename __T>
-	inline bool isA() const noexcept{
+	inline constexpr bool isA() const noexcept {
 		return isA(__T::staticClass());
 	}
 
@@ -93,7 +116,7 @@ public:
 	 * @return The class matching the ID from the ClassRegistry.
 	 */
 	static inline const Class* getClasByID(uint64_t ID) noexcept {
-		if(registry == nullptr){
+		if(registry == nullptr) {
 			return nullptr;
 		}
 
@@ -103,7 +126,7 @@ public:
 	/**
 	 * @return The name of the object type the class represents.
 	 */
-	inline virtual constexpr std::string getName() const noexcept{
+	inline virtual constexpr std::string getName() const noexcept {
 		return "Object";
 	}
 
@@ -112,13 +135,6 @@ protected:
 
 protected:
 	/**
-	 * @brief Constructor of the class with given ID. The ID is generated partially at compile time,
-	 * and partially at the beginning of the runtime statically.
-	 * @param ID The generated ID of the class.
-	 */
-	explicit Class(uint64_t ID) noexcept;
-
-	/**
 	 * @return An object represented by this class.
 	 */
 	virtual StrongObjectPtr<Object> __createObject(void* arguments) const noexcept;
@@ -126,5 +142,94 @@ protected:
 private:
 	uint64_t classID;
 };
+
+/**
+ * @brief Helper used at static initialization to register a class instance with the ClassRegistry.
+ * Registration is moved out of the Class constructor so that Class can have a constexpr constructor.
+ */
+class ClassRegistrar {
+public:
+	explicit ClassRegistrar(const Class* cls) noexcept {
+		if(Class::registry == nullptr) {
+			Class::registry = new ClassRegistry();
+		}
+
+		Class::registry->registerClass(cls);
+	}
+};
+
+/**
+ * @brief Type list used to wrap a parameter pack of types to be passed as a single template argument.
+ */
+template<typename... Types>
+struct TypeList {};
+
+/**
+ * @brief Generic templated Class implementation used by GENERATED_BODY for any object type.
+ * Defined at namespace scope (not nested inside the user class) so that its constexpr constructor
+ * is fully parsed by the time the user class's static constexpr instance is initialized.
+ *
+ * @tparam Derived The user-defined Object subclass that this Class describes.
+ * @tparam Super The direct base Object subclass of Derived.
+ * @tparam CtorList TypeList of constructor argument types for Derived (or TypeList<void> for default constructor).
+ * @tparam Interfaces Pack of interface types implemented by Derived.
+ */
+template<typename Derived, typename Super, typename CtorList, typename... Interfaces>
+class GenericClass;
+
+template<typename Derived, typename Super, typename... CtorArgs, typename... Interfaces>
+class GenericClass<Derived, Super, TypeList<CtorArgs...>, Interfaces...> : public Class {
+public:
+	constexpr explicit GenericClass(uint64_t ID) noexcept : Class(ID) {}
+
+	constexpr virtual ~GenericClass() noexcept override = default;
+
+	template<typename T>
+	static inline constexpr bool implements() noexcept {
+		if constexpr (sizeof...(Interfaces) > 0) {
+			return std::is_same_v<T, Super> || (std::is_same_v<T, Interfaces> || ...);
+		} else {
+			return std::is_same_v<T, Super>;
+		}
+	}
+
+	constexpr virtual bool isA(const Class* other) const noexcept override {
+		if(other == nullptr) {
+			return false;
+		}
+
+		return other->getID() == Class::getID() || Super::staticClass()->isA(other);
+	}
+
+	template<typename T>
+	inline constexpr bool isA() const noexcept {
+		return isA(T::staticClass());
+	}
+
+	inline virtual constexpr std::string getName() const noexcept override {
+		const std::string templates = Derived::__getTemplateNames();
+		return std::string(Derived::__className) + (templates.empty() ? "" : "<" + templates + ">");
+	}
+
+	inline virtual StrongObjectPtr<Object> __createObject(void* arguments) const noexcept override {
+		void* temp = operator new(sizeof(Derived));
+		if(temp == nullptr) {
+			return nullptr;
+		}
+
+		memset(temp, 0, sizeof(Derived));
+
+		StrongObjectPtr<Derived> tempPtr = static_cast<Derived*>(temp);
+		ObjectConstruct<Derived, CtorArgs...> construct(arguments);
+
+		return construct.create(temp);
+	}
+};
+
+// Bring in Object so that headers which historically included only Class.h still see Object.
+// Object.h includes Class.h, but its include guard prevents recursion: when Object.h is the
+// translation entry, this trailing include is a no-op; when Class.h is the entry, Object.h is
+// pulled in here after Class and GenericClass are fully defined.
+#include "Object.h"
 
 #endif //CMF_CLASS_H

--- a/src/Object/Object.cpp
+++ b/src/Object/Object.cpp
@@ -7,7 +7,8 @@
 #include "Core/Application.h"
 #include "Class.h"
 
-const Object::ClassType* Object::objectStaticClass = new Object::ClassType(static_cast<uint64_t>(STRING_HASH("Object")) << 32);
+constexpr Object::ClassType Object::objectStaticClass;
+const ClassRegistrar Object::__objectClassRegistrar{&Object::objectStaticClass};
 
 Object::Object() noexcept : id(ObjectIndex++){}
 
@@ -28,14 +29,6 @@ Object::~Object() noexcept {
 }
 std::string Object::getName() const noexcept {
 	return getStaticClass()->getName().append("_").append(std::to_string(getID()));
-}
-
-bool Object::isA(const Class* other) const noexcept {
-	if(other == nullptr) {
-		return false;
-	}
-
-	return other->getID() == staticClass()->getID();
 }
 
 void Object::postInitProperties() noexcept{}

--- a/src/Object/Object.h
+++ b/src/Object/Object.h
@@ -14,9 +14,7 @@
 #include "Containers/Queue.h"
 #include "Containers/Archive.h"
 #include "ObjectConstruct.h"
-
-class Class;
-class ClassRegistry;
+#include "Class.h"
 
 /**
  * @brief The Object class is the backbone of the whole framework, and the basis behind most functionality.
@@ -50,8 +48,8 @@ public:
 	/**
 	 * @return The static class of the object.
 	 */
-	inline static const Class* staticClass() noexcept{
-		return objectStaticClass;
+	static inline constexpr const Class* staticClass() noexcept{
+		return &objectStaticClass;
 	}
 
 	/**
@@ -66,7 +64,13 @@ public:
 	 * @param other The type class being compared to.
 	 * @return True if same type or derived from it, false otherwise.
 	 */
-	virtual bool isA(const Class* other) const noexcept;
+	inline constexpr virtual bool isA(const Class* other) const noexcept {
+		if(other == nullptr) {
+			return false;
+		}
+
+		return other->getID() == staticClass()->getID();
+	}
 
 	/**
 	 * @brief Checks if this object is of type given in the template, or derived from it.
@@ -74,7 +78,7 @@ public:
 	 * @return True if same type or derived from it, false otherwise.
 	 */
 	template<typename __T>
-	inline bool isA() const noexcept{
+	inline constexpr bool isA() const noexcept{
 		return isA(__T::staticClass());
 	}
 
@@ -203,9 +207,10 @@ public:
 	 */
 	Object* getOutermostInstigator() const noexcept;
 
-protected:
+public:
 	/**
 	 * @return The template names used for information about template types of the instance for the class ID hash.
+	 * Public so that GenericClass (declared at namespace scope) can read it via the Derived class.
 	 */
 	inline static constexpr std::string __getTemplateNames() noexcept{
 		return "";
@@ -213,14 +218,23 @@ protected:
 
 	/**
 	 * @return The hash of all template names used for the class ID.
+	 * Public for the same reason as __getTemplateNames.
 	 */
 	inline static constexpr uint32_t __getTemplateHash() noexcept{
 		return 0;
 	}
 
+	/**
+	 * @brief The string identifier of this class, used by GenericClass::getName().
+	 * Re-declared by GENERATED_BODY for each derived class.
+	 */
+	static constexpr const char* __className = "Object";
+
 private:
 	using ClassType = Class;
-	static const ClassType* objectStaticClass;
+	static constexpr ClassType objectStaticClass{static_cast<uint64_t>(STRING_HASH("Object")) << 32};
+	static const ClassRegistrar __objectClassRegistrar;
+
 	inline static uint32_t ObjectIndex = 0;
 
 	const uint32_t id;
@@ -271,6 +285,7 @@ private:																																			        \
  * This macro should be defined at the beginning of the class in the header file.
  * @param ObjectName The name of this class.
  * @param SuperObject The object-base class being extended by this class.
+ * @param ConstructorTypes Comma-separated constructor argument types wrapped in CONSTRUCTOR_PACK(...), or 'void' for a default constructor.
  * @param ... The interfaces being implemented by this class.
  */
 #define GENERATED_BODY(ObjectName, SuperObject, ConstructorTypes, ...) 																		                				\
@@ -279,109 +294,35 @@ private:																																			        \
 																																											\
 	friend struct ObjectConstruct<ObjectName, ConstructorTypes>;																											\
 																															                                				\
-private:																													                                				\
-	template<typename... __Types>																							                                				\
-	class __##ObjectName##_Class;																							                                				\
-																															                                				\
-	template<typename __T>																									                                				\
-	class __##ObjectName##_Class<__T> : public Class {																		                                				\
-	public:																													                                				\
-		friend class ObjectName;																							                                				\
-																															                                				\
-	public:																													                                				\
-		template<typename __Type>																							                                				\
-		inline static constexpr bool implements() noexcept {                 												                                				\
-			return std::is_same<__Type, __T>::value;																		                                				\
-		}                                                                    												                                				\
-																																											\
-		inline virtual bool isA(const Class* other) const noexcept override {													                            				\
-			if(other == nullptr){																																			\
-				return false;																																				\
-			}																																								\
-																																											\
-			return other->getID() == Class::getID() || SuperObject::staticClass()->isA(other);																				\
-		}																														                            				\
-																																											\
-		template<typename __Type>																									                        				\
-		inline bool isA() const noexcept {																						                            				\
-			return isA(__Type::staticClass());																						                        				\
-		}																																									\
-																															                                				\
-		inline virtual constexpr std::string getName() const noexcept override{												                                				\
-			const std::string __templates = __getTemplateNames();																											\
-			const std::string __ret = std::string(#ObjectName) + (__templates.empty() ? "" : "<" + __templates + ">");														\
-			return __ret;																																					\
-		}																													                                				\
-																															                                				\
-	protected:                                             																	                                				\
-		explicit inline __##ObjectName##_Class(uint64_t ID) noexcept : Class(ID) {}											                                				\
-																																											\
-		inline virtual StrongObjectPtr<Object> __createObject(void* arguments) const noexcept override {  											        				\
-			void* __temp = operator new(sizeof(ObjectName));																	                                			\
-			if(__temp == nullptr) {																								                            				\
-				return nullptr;																																				\
-			}																													                            				\
-																																											\
-			memset(__temp, 0, sizeof(ObjectName));																			                                				\
-																																											\
-			StrongObjectPtr<ObjectName> __tempPtr = static_cast<ObjectName*>(__temp);																						\
-			ObjectConstruct<ObjectName, ConstructorTypes> construct(arguments);																								\
-																																											\
-			return construct.create(__temp);																																\
-		}																																									\
-	};																														                                				\
-																															                                				\
-	template<typename __T, typename... __Types>																				                                				\
-	class __##ObjectName##_Class<__T, __Types...> : public __##ObjectName##_Class<__Types...> {								                                				\
-		typedef __##ObjectName##_Class<__Types...> Inherited;																                                				\
-																															                                				\
-	public:																													                                				\
-		friend class ObjectName;																							                                				\
-																															                                				\
-	public:																													                                				\
-		template<typename __Type>																							                                				\
-		inline static constexpr bool implements() noexcept {                 												                                				\
-			return std::is_same<__Type, __T>::value || Inherited::template implements<__Type>();							                                				\
-		}																													                                				\
-																																											\
-		inline virtual bool isA(const Class* other) const noexcept override {													                            				\
-			return other->getID() == Class::getID() || Inherited::isA(other) || SuperObject::staticClass()->isA(other);														\
-		}																														                            				\
-																																											\
-		template<typename __Type>																									                        				\
-		inline bool isA() const noexcept {																						                            				\
-			return isA(__Type::staticClass());																																\
-		}																																									\
-																																											\
-	protected:																												                                				\
-		explicit inline __##ObjectName##_Class(uint64_t ID) noexcept : __##ObjectName##_Class<__Types...>(ID) {}			                                				\
-	};																														                                				\
-																															                                				\
-	using Super = SuperObject;																								                                				\
-	using ClassType = __##ObjectName##_Class<Super, ##__VA_ARGS__>;															                                				\
-	inline static const ClassType* objectStaticClass = new ClassType(((uint64_t) STRING_HASH(#ObjectName) << 32) | __getTemplateHash());									\
-																															                                				\
 public:																														                                				\
-	inline static const Class* staticClass() noexcept {																		                                				\
-		return objectStaticClass;																							                                				\
+	using Super = SuperObject;																								                                				\
+	using ClassType = GenericClass<ObjectName, Super, TypeList<ConstructorTypes>, ##__VA_ARGS__>;																			\
+	friend ClassType;																																						\
+																															                                				\
+	static constexpr const char* __className = #ObjectName;																													\
+	inline static constexpr ClassType objectStaticClass{((uint64_t) STRING_HASH(#ObjectName) << 32) | __getTemplateHash()};													\
+	inline static const ClassRegistrar __##ObjectName##_classRegistrar{&objectStaticClass};																					\
+																															                                				\
+	static inline constexpr const Class* staticClass() noexcept {															                                				\
+		return &objectStaticClass;																							                                				\
 	}																														                                				\
 																															                                				\
 	inline virtual const Class* getStaticClass() const noexcept override {													                                				\
 		return staticClass();																								                                				\
 	}																														                                				\
 																															                                				\
-	inline virtual bool isA(const Class* other) const noexcept override {													                                				\
-		return other->getID() == staticClass()->getID() || Super::isA(other);												                                				\
+	inline constexpr virtual bool isA(const Class* other) const noexcept override {											                                				\
+		return other != nullptr && (other->getID() == staticClass()->getID() || Super::isA(other));							                                				\
 	}																														                                				\
 																															                                				\
 	template<typename __T>																									                                				\
-	inline bool isA() const noexcept {																						                                				\
+	inline constexpr bool isA() const noexcept {																			                                				\
 		return isA(__T::staticClass());																						                                				\
 	}																														                                				\
 																															                                				\
 	template<typename __T>																									                                				\
 	inline static constexpr bool implements() noexcept {																	                                				\
-		return objectStaticClass->template implements<__T>() || Super::template implements<__T>();							                                				\
+		return ClassType::template implements<__T>() || Super::template implements<__T>();									                                				\
 	}                                                      																	                                				\
 private:																																									\
 

--- a/src/Services/Audio/AudioGenerator.h
+++ b/src/Services/Audio/AudioGenerator.h
@@ -1,6 +1,7 @@
 #ifndef CMF_AUDIOGENERATOR_H
 #define CMF_AUDIOGENERATOR_H
 
+#include <memory>
 #include "Object/Class.h"
 #include "AudioSource.h"
 


### PR DESCRIPTION
## Summary

Allows `SubclassOf<T>` to be used in `constexpr` variables, e.g.

```cpp
static constexpr SubclassOf<State> initial = MyState::staticClass();
```

To make this work, `Class` needs to be a literal type with a `constexpr` constructor, `staticClass()` must return a `constexpr`-evaluable pointer, and `Class::isA` must be `constexpr` virtual. The `Class.h` ↔ `Object.h` circular dependency is also resolved as part of this change.

## Changes

- **`src/Object/Class.h`** — structure rewritten. `Class` now has a body-less `constexpr` constructor (`: classID(ID) {}`). Registry registration is moved to a new `ClassRegistrar` helper whose non-`constexpr` constructor performs the runtime registration; each class owns one as an `inline static const` member. The per-class nested `__<Name>_Class<...>` template hierarchy is replaced by a single namespace-scope `GenericClass<Derived, Super, TypeList<CtorArgs...>, Interfaces...>` template so its `constexpr` ctor body is fully visible at NSDMI instantiation time (GCC would otherwise reject the nested form with "used before its definition").
- **`src/Object/Class.cpp`** — constructor body and `Class::isA` removed (now `constexpr` inline in the header).
- **`src/Object/Object.h`** — now includes `Class.h` directly; `objectStaticClass` is a `constexpr` instance; `staticClass()` / `isA` are `constexpr`; `GENERATED_BODY` fully restructured around `GenericClass`. Object's helper accessors were promoted from `protected` to `public` so `GenericClass::getName()` can read them through the `Derived` qualifier.
- **`src/Object/Object.cpp`** — out-of-class definition of `Object::objectStaticClass` and its registrar.
- **`src/Misc/TemplateTypes.h`** — `TypesHash()` made truly `constexpr` by replacing `std::to_string` (not `constexpr` in C++23) with an in-class `__constexpr_to_string` helper. Same hashing algorithm, so existing class IDs are stable.
- **`src/Services/Audio/AudioGenerator.h`** — added `#include <memory>` (transitive include via the old `Class.h` → `Object.h` chain is no longer guaranteed).

## Circular dependency

`Class.h` no longer includes `Object.h` ahead of its own definitions — it only forward-declares `Object` and is self-contained. The actual code dependency is now one-directional: `Object.h` → `Class.h`. A trailing `#include "Object.h"` is kept at the bottom of `Class.h` as a backward-compat shim so that the ~45 existing source files that include only `Class.h` while inheriting from `Object` keep working without a repo-wide include sweep.

## Verification

- Built cleanly against ESP-IDF v5.5.3 (esp32s3, C++23) using a host consumer project.
- During development, `static_assert`s in `Object.cpp` verified `constexpr` evaluation for: base case (`SubclassOf<Object> = Object::staticClass()`), derived-to-base (`SubclassOf<Object> = Threaded::staticClass()`, exercises `GenericClass::isA` virtual `constexpr` dispatch), exact match (`SubclassOf<Threaded> = Threaded::staticClass()`), and `nullptr`. All passed; the asserts were removed before commit since CMF has no test infrastructure to host them.

## Test plan

- [ ] Clean build in a consumer project with `-std=gnu++2b` / C++23.
- [ ] Replace a `static const SubclassOf<...>` with `static constexpr SubclassOf<...>` in a consumer and confirm it compiles.
- [ ] Spot-check that existing non-`constexpr` `SubclassOf` / `staticClass()` / `isA` / `Cast` usage still behaves identically at runtime (class IDs unchanged).