### PR TITLE
Object::scanEvents, StateMachine fixes

### DIFF
--- a/src/Event/EventScanner.cpp
+++ b/src/Event/EventScanner.cpp
@@ -1,7 +1,7 @@
 #include "EventScanner.h"
 #include "EventHandle.h"
 
-EventScanner::EventScanner() : Super(0, 4 * 1024, 10) {
+EventScanner::EventScanner() : Super(0, 4 * 1024, 20) {
     semaphore = xSemaphoreCreateBinary();
 }
 

--- a/src/Object/Object.cpp
+++ b/src/Object/Object.cpp
@@ -129,12 +129,14 @@ void Object::scanEvents(TickType_t wait) noexcept{
 
 	const uint64_t begin = millis();
 
-	for(EventHandleBase* handle = nullptr; readyEventHandles.pop(handle, std::max(static_cast<int64_t>(0), static_cast<int64_t>(wait) - (static_cast<int64_t>(millis()) - static_cast<int64_t>(begin)))); ){
+	auto eventWaitTime = std::max(static_cast<int64_t>(0), static_cast<int64_t>(wait) - (static_cast<int64_t>(millis()) - static_cast<int64_t>(begin)));
+	for(EventHandleBase* handle = nullptr; readyEventHandles.pop(handle,eventWaitTime ); ){
 		if(handle == nullptr){
 			continue;
 		}
 
 		handle->scan(0);
+		eventWaitTime = 0;
 	}
 
 	// WARNING: This will not work, or will create an infinite loop if owner system is abused, this is intentional, events are dependent on their owner to scan events, outermost owner must be an async entity for this to work

--- a/src/Util/StateMachine/StateMachine.cpp
+++ b/src/Util/StateMachine/StateMachine.cpp
@@ -48,5 +48,6 @@ void StateMachine::tick(float deltaTime) noexcept{
 		}
 	}else if(startingStateType != nullptr) {
 		current = newObject<State>(*startingStateType, this);
+		startingStateType = nullptr;
 	}
 }


### PR DESCRIPTION
ScanEvents blocking only on 1st event, StateMachine bugfix, EventScanner priority increased.