### PR TITLE
Silent fails and logging (CMF-56)

### DIFF
--- a/src/Core/Application.cpp
+++ b/src/Core/Application.cpp
@@ -19,6 +19,7 @@ Application::~Application() noexcept {
 
 	ObjectManager* manager = ObjectManager::get();
 	if(manager == nullptr){
+		CMF_LOG(CMF, LogLevel::Warning, "Application destroyed without an ObjectManager available, skipping cleanup");
 		return;
 	}
 

--- a/src/Core/Application.h
+++ b/src/Core/Application.h
@@ -6,6 +6,7 @@
 #include "Object/Class.h"
 #include "Entity/AsyncEntity.h"
 #include "Object/SubclassOf.h"
+#include "Log/Log.h"
 #include "Memory/GarbageCollector.h"
 #include "Memory/ObjectMemory.h"
 #include "Misc/Singleton.h"
@@ -90,6 +91,7 @@ public:
 		}
 
 		if(!newSingleton.isValid()){
+			CMF_LOG(CMF, LogLevel::Error, "registerSingleton: failed to construct singleton object");
 			return nullptr;
 		}
 
@@ -229,6 +231,7 @@ protected:
 	T* registerPeriphery(Args&&... args) noexcept requires(std::derived_from<T, Object>) {
 		StrongObjectPtr<T> object = newObject<T>(this, args...);
 		if(!object.isValid()){
+			CMF_LOG(CMF, LogLevel::Error, "registerPeriphery: failed to construct periphery object");
 			return nullptr;
 		}
 
@@ -248,6 +251,7 @@ protected:
 	T* registerDevice(Args&&... args) noexcept requires(std::derived_from<T, Object>) {
 		StrongObjectPtr<T> object = newObject<T>(this, args...);
 		if(!object.isValid()){
+			CMF_LOG(CMF, LogLevel::Error, "registerDevice: failed to construct device object");
 			return nullptr;
 		}
 
@@ -267,6 +271,7 @@ protected:
 	T* registerDriver(Args&&... args) noexcept requires(std::derived_from<T, Object>){
 		StrongObjectPtr<T> object = newObject<T>(this, args...);
 		if(!object.isValid()){
+			CMF_LOG(CMF, LogLevel::Error, "registerDriver: failed to construct driver object");
 			return nullptr;
 		}
 
@@ -286,6 +291,7 @@ protected:
 	T* registerService(Args&&... args) noexcept requires(std::derived_from<T, Object>){
 		StrongObjectPtr<T> object = newObject<T>(this, std::forward<Args>(args)...);
 		if(!object.isValid()){
+			CMF_LOG(CMF, LogLevel::Error, "registerService: failed to construct service object");
 			return nullptr;
 		}
 

--- a/src/Devices/AW9523.cpp
+++ b/src/Devices/AW9523.cpp
@@ -1,6 +1,6 @@
 #include "AW9523.h"
 #include "Util/stdafx.h"
-#include <esp_log.h>
+#include "Log/Log.h"
 #include <Core/Application.h>
 #define REG_RESET 0x7F
 #define REG_ID 0x10
@@ -25,35 +25,37 @@ static uint8_t AW_BIT(uint8_t pin){ return (pin <= 7) ? pin : (pin - 8); }
 
 static uint8_t AW_MASK(uint8_t pin){ return 1 << AW_BIT(pin); }
 
-static const char* TAG = "AW9523";
+DEFINE_LOG(AW9523)
 
 const uint8_t AW9523::dimmap[16] = { 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 12, 13, 14, 15 };
 
 AW9523::AW9523(I2CMaster* i2c, uint8_t addr){
 	if(i2c == nullptr){
+		CMF_LOG(AW9523, LogLevel::Error, "I2C master is null, aborting initialization");
 		return;
 	}
 
 	const Application* app = getApp();
 	if(app == nullptr){
+		CMF_LOG(AW9523, LogLevel::Error, "Application instance unavailable, aborting initialization");
 		return;
 	}
 
 	dev = std::move(i2c->addDevice(addr));
 
 	if(!dev){
-		ESP_LOGE(TAG, "I2C device is null");
+		CMF_LOG(AW9523, LogLevel::Error, "I2C device is null");
 		abort();
 	}
 
 	uint8_t id = 0;
 	if(dev->readRegister(REG_ID, id) != ESP_OK){
-		ESP_LOGE(TAG, "Transmission error");
+		CMF_LOG(AW9523, LogLevel::Error, "Transmission error reading ID register");
 		abort();
 	}
 
 	if(id != VAL_ID){
-		ESP_LOGE(TAG, "ID missmatch: expected %d, got %d", VAL_ID, id);
+		CMF_LOG(AW9523, LogLevel::Error, "ID missmatch: expected %d, got %d", VAL_ID, id);
 		return;
 	}
 

--- a/src/Devices/BM8563.cpp
+++ b/src/Devices/BM8563.cpp
@@ -1,23 +1,24 @@
 #include "BM8563.h"
+#include "Log/Log.h"
 #include "Periphery/I2CMaster.h"
 
-static const char* TAG = "BM8563";
+DEFINE_LOG(BM8563)
 
 BM8563::BM8563(I2CMaster* i2c, uint8_t Addr) : Addr(Addr){
 	if(!i2c){
-		ESP_LOGE(TAG, "No I2C peripheral provided");
+		CMF_LOG(BM8563, LogLevel::Error, "No I2C peripheral provided");
 		abort();
 	}
 
 	dev = i2c->addDevice(Addr);
 	if(!dev){
-		ESP_LOGE(TAG, "I2C device is null");
+		CMF_LOG(BM8563, LogLevel::Error, "I2C device is null");
 		abort();
 	}
 
 	// Clear status registers (0x0 and 0x1)
 	if(const auto ret = dev->write({ 0, 0, 0 }, 10); ret != ESP_OK){
-		ESP_LOGE(TAG, "Error clearing status registers: %d", ret);
+		CMF_LOG(BM8563, LogLevel::Error, "Error clearing status registers: %d", ret);
 		abort();
 	}
 }
@@ -25,7 +26,10 @@ BM8563::BM8563(I2CMaster* i2c, uint8_t Addr) : Addr(Addr){
 tm BM8563::getTime(){
 	uint8_t data[7];
 	constexpr uint8_t writeData = 0x02;
-	if(dev->write_read(&writeData, 1, data, 7) != ESP_OK) return {};
+	if(dev->write_read(&writeData, 1, data, 7) != ESP_OK){
+		CMF_LOG(BM8563, LogLevel::Warning, "Failed reading time registers, returning zero time");
+		return {};
+	}
 
 	tm time = {};
 

--- a/src/Devices/Camera.cpp
+++ b/src/Devices/Camera.cpp
@@ -104,7 +104,7 @@ camera_fb_t* Camera::getFrame(){
 
 	if(frame == nullptr){
 		failedFrames++;
-		CMF_LOG(Camera, LogLevel::Warning, "esp_camera_fb_get returned null (%u/%u failed frames)", (unsigned) failedFrames, (unsigned) MaxFailedFrames);
+		CMF_LOG(Camera, LogLevel::Info, "esp_camera_fb_get returned null (%u/%u failed frames)", (unsigned) failedFrames, (unsigned) MaxFailedFrames);
 
 		if(failedFrames >= MaxFailedFrames){
 			CMF_LOG(Camera, LogLevel::Error, "Reached max failed frames, deinitializing camera");

--- a/src/Devices/Camera.cpp
+++ b/src/Devices/Camera.cpp
@@ -4,11 +4,10 @@
 #include "Periphery/I2CMaster.h"
 
 DEFINE_LOG(Camera)
-static constexpr const char* TAG = "Camera";
 
 Camera::Camera(camera_config_t config, I2CMaster* i2c, std::function<void(sensor_t*)> sensorConfig) : config(config), i2c(i2c), sensorConfig(sensorConfig){
 	if(!i2c){
-		ESP_LOGE(TAG, "I2C interface is null");
+		CMF_LOG(Camera, LogLevel::Error, "I2C interface is null");
 		abort();
 	}
 
@@ -51,6 +50,7 @@ esp_err_t Camera::init(){
 
 	auto err = esp_camera_init(&config);
 	if(err == ESP_ERR_NOT_FOUND){
+		CMF_LOG(Camera, LogLevel::Warning, "Camera not found during init");
 		return err;
 	}else if(err != ESP_OK){
 		CMF_LOG(Camera, LogLevel::Error, "Camera init failed with error 0x%x: %s\n", err, esp_err_to_name(err));
@@ -59,6 +59,7 @@ esp_err_t Camera::init(){
 
 	sensor_t* sensor = esp_camera_sensor_get();
 	if(sensor == nullptr){
+		CMF_LOG(Camera, LogLevel::Error, "Camera sensor not detected after init");
 		return ESP_ERR_CAMERA_NOT_DETECTED;
 	}
 
@@ -103,8 +104,10 @@ camera_fb_t* Camera::getFrame(){
 
 	if(frame == nullptr){
 		failedFrames++;
+		CMF_LOG(Camera, LogLevel::Warning, "esp_camera_fb_get returned null (%u/%u failed frames)", (unsigned) failedFrames, (unsigned) MaxFailedFrames);
 
 		if(failedFrames >= MaxFailedFrames){
+			CMF_LOG(Camera, LogLevel::Error, "Reached max failed frames, deinitializing camera");
 			deinit();
 		}
 	}else{

--- a/src/Devices/LIS2DW12.cpp
+++ b/src/Devices/LIS2DW12.cpp
@@ -1,11 +1,12 @@
 #include "LIS2DW12.h"
+#include "Log/Log.h"
 
-static constexpr const char* TAG = "LIS2DW12";
+DEFINE_LOG(LIS2DW12)
 
 LIS2DW12::LIS2DW12(std::unique_ptr<I2CDevice> i2cDevice, PinConfig pinConfig, Config config, uint8_t addr) : i2c(std::move(i2cDevice)), Addr(addr), config(config), pins(pinConfig),
 																				 dispatcherThread([this](){ dispatcherFunc(); }, "LIS2_dispatcher", 0, 2 * 1024, 8){
 	if(!i2c){
-		ESP_LOGE(TAG, "No I2C peripheral provided");
+		CMF_LOG(LIS2DW12, LogLevel::Error, "No I2C peripheral provided");
 		abort();
 	}
 
@@ -45,13 +46,13 @@ LIS2DW12::Sample LIS2DW12::getSample(){
 
 LIS2DW12::Sample LIS2DW12::pollFIFO(TickType_t timeout) const {
 	if(!queue){
-		ESP_LOGE(TAG, "FIFO not enabled");
+		CMF_LOG(LIS2DW12, LogLevel::Error, "FIFO not enabled");
 		return Sample{};
 	}
 
 	Sample sample{};
 	if(xQueueReceive(queue, &sample, timeout) != pdTRUE){
-		ESP_LOGW(TAG, "Timeout waiting for FIFO sample");
+		CMF_LOG(LIS2DW12, LogLevel::Warning, "Timeout waiting for FIFO sample");
 		return Sample{};
 	}
 	return sample;
@@ -67,7 +68,7 @@ void LIS2DW12::init(Config config, PinConfig pins){
 	uint8_t id;
 	lis2dw12_device_id_get(&ctx, &id);
 	if(id != LIS2DW12_ID){
-		ESP_LOGE(TAG, "Init error, got ID 0x%x, expected 0x%x", id, LIS2DW12_ID);
+		CMF_LOG(LIS2DW12, LogLevel::Error, "Init error, got ID 0x%x, expected 0x%x", id, LIS2DW12_ID);
 		abort();
 	}
 
@@ -181,9 +182,12 @@ void IRAM_ATTR LIS2DW12::isr(void* arg){
 }
 
 void LIS2DW12::dispatcherFunc(){
-	if(xSemaphoreTake(dispatcherSem, portMAX_DELAY) != pdTRUE) return;
+	if(xSemaphoreTake(dispatcherSem, portMAX_DELAY) != pdTRUE){
+		CMF_LOG(LIS2DW12, LogLevel::Warning, "Failed taking dispatcher semaphore");
+		return;
+	}
 
-	printf("dispatcher unblocked\n");
+	CMF_LOG(LIS2DW12, LogLevel::Verbose, "dispatcher unblocked");
 
 	while(gpio_get_level(pins.int1) || gpio_get_level(pins.int2)){
 		fetchEvents();

--- a/src/Devices/TCA9555.cpp
+++ b/src/Devices/TCA9555.cpp
@@ -1,5 +1,6 @@
 #include "TCA9555.h"
 #include "Core/Application.h"
+#include "Log/Log.h"
 #include "Periphery/I2CMaster.h"
 #include "Periphery/I2CDevice.h"
 
@@ -11,18 +12,18 @@ static inline uint8_t TCA_BIT(uint8_t pin){ return (pin <= 7) ? pin : (pin - 8);
 
 static inline uint8_t TCA_MASK(uint8_t pin){ return 1 << TCA_BIT(pin); }
 
-static const char* TAG = "TCA9555";
+DEFINE_LOG(TCA9555)
 
 
 TCA9555::TCA9555(I2CMaster* i2c, uint8_t addr){
 	if(!i2c){
-		ESP_LOGE(TAG, "I2C master is null");
+		CMF_LOG(TCA9555, LogLevel::Error, "I2C master is null");
 		abort();
 	}
 
 	dev = i2c->addDevice(addr);
 	if(!dev){
-		ESP_LOGE(TAG, "I2C device is null");
+		CMF_LOG(TCA9555, LogLevel::Error, "I2C device is null");
 		abort();
 	}
 

--- a/src/Devices/Timer.cpp
+++ b/src/Devices/Timer.cpp
@@ -1,9 +1,9 @@
 #include "Timer.h"
-#include <esp_log.h>
+#include "Log/Log.h"
 
 #include <utility>
 
-static const char* TAG = "Timer";
+DEFINE_LOG(Timer)
 
 Timer::Timer(uint32_t period, std::function<void()> ISR, const char* name) : period(period * 1000), ISR(std::move(ISR)){
 	char timerName[32];
@@ -70,7 +70,7 @@ void Timer::single(uint32_t delay, std::function<void()> ISR){
 
 void IRAM_ATTR Timer::setPeriod(uint32_t period){
 	if(esp_timer_is_active(timer)){
-		ESP_LOGE(TAG, "setPeriod called while timer is running");
+		CMF_LOG(Timer, LogLevel::Error, "setPeriod called while timer is running");
 		return;
 	}
 

--- a/src/Drivers/Input/InputGPIO.cpp
+++ b/src/Drivers/Input/InputGPIO.cpp
@@ -1,6 +1,8 @@
 #include "InputGPIO.h"
 #include "Log/Log.h"
 
+DEFINE_LOG(InputGPIO)
+
 InputGPIO::InputGPIO(const std::vector<GPIOPinDef>& inputs, StrongObjectPtr<GPIOPeriph> gpio) noexcept:
 	Super(toInputPinDef(inputs)), gpio(std::move(gpio)){
 
@@ -27,7 +29,7 @@ void InputGPIO::performRegister(const InputPinDef& input) noexcept{
 	gpio->setMode((gpio_num_t) input.port, GPIOMode::Input);
 
 	if(!pullModes.contains(input.port)){
-		ESP_LOGE("InputGPIO", "No pull mode defined for pin %d", input.port);
+		CMF_LOG(InputGPIO, LogLevel::Error, "No pull mode defined for pin %d", input.port);
 	}
 
 	const auto pin = (gpio_num_t) input.port;

--- a/src/Drivers/Input/InputTouchGPIO.cpp
+++ b/src/Drivers/Input/InputTouchGPIO.cpp
@@ -1,5 +1,8 @@
 #include "InputTouchGPIO.h"
+#include "Log/Log.h"
 #include <driver/touch_pad.h>
+
+DEFINE_LOG(InputTouchGPIO)
 
 InputTouchGPIO::InputTouchGPIO(const std::vector<TouchPinDef>& inputs) noexcept: Super(toInputPinDef(inputs)){
 	for(const auto& input : inputs){
@@ -39,7 +42,7 @@ void InputTouchGPIO::performRegister(const InputPinDef& input) noexcept{
 	touch_pad_config(touchPin);
 
 	if(!thresholds.contains(input.port)){
-		ESP_LOGE("InputTouchGPIO", "Threshold for pin %d not defined", input.port);
+		CMF_LOG(InputTouchGPIO, LogLevel::Error, "Threshold for pin %d not defined", input.port);
 		return;
 	}
 

--- a/src/Drivers/Output/OutputPWM.cpp
+++ b/src/Drivers/Output/OutputPWM.cpp
@@ -68,7 +68,7 @@ void OutputPWM::performWrite(int port, float value) noexcept{
 
 void OutputPWM::performRegister(const OutputPinDef& output) noexcept{
 	if(!gpios.contains(output.port)){
-		ESP_LOGE("OutputPWM", "Output port %d not found in pin map", output.port);
+		CMF_LOG(PWM, Error, "Output port %d not found in pin map", output.port);
 		return;
 	}
 

--- a/src/FileSystem/ArchiveCache.cpp
+++ b/src/FileSystem/ArchiveCache.cpp
@@ -1,7 +1,9 @@
 #include "ArchiveCache.h"
 #include "SPIFFS.h"
-#include <esp_log.h>
+#include "Log/Log.h"
 #include <cstring>
+
+DEFINE_LOG(ArchiveCache)
 
 ArchiveCache::ArchiveCache(const std::vector<std::string>& paths) : paths(paths){
 	archives.reserve(paths.size());
@@ -16,7 +18,7 @@ void ArchiveCache::load(){
 
 		auto file = SPIFFS::open(filename.c_str());
 		if(!file){
-			ESP_LOGW("ArchiveCache", "Can't open archive %s", path.c_str());
+			CMF_LOG(ArchiveCache, LogLevel::Warning, "Can't open archive %s", path.c_str());
 			continue;
 		}
 

--- a/src/FileSystem/FSFileImpl.cpp
+++ b/src/FileSystem/FSFileImpl.cpp
@@ -1,14 +1,14 @@
 #include "FSFileImpl.h"
+#include "Log/Log.h"
 #include <cstring>
-#include <esp_log.h>
 
-static const char* TAG = "FSFile";
+DEFINE_LOG(FSFile)
 
 FSFileImpl::FSFileImpl(const char* path, const char* mode) : filePath(path){
 	file = fopen(path, mode);
 
 	if(file == nullptr){
-		ESP_LOGE(TAG, "Can't open file %s", path);
+		CMF_LOG(FSFile, LogLevel::Error, "Can't open file %s", path);
 		return;
 	}
 

--- a/src/FileSystem/FileArchive.cpp
+++ b/src/FileSystem/FileArchive.cpp
@@ -1,9 +1,9 @@
 #include "FileArchive.h"
 #include <vector>
-#include <esp_log.h>
+#include "Log/Log.h"
 #include "FileSystem/RamFile.h"
 
-static const char* TAG = "FileArchive";
+DEFINE_LOG(FileArchive)
 
 FileArchive::FileArchive(File file, const std::unordered_set<std::string>& excluded){
 	file.seek(0);
@@ -20,7 +20,7 @@ FileArchive::FileArchive(File file, const std::unordered_set<std::string>& exclu
 		name.reserve(32);
 		while(file.available()){
 			if(name.length() >= 32){
-				ESP_LOGE("FileArchive", "Too big filename; %s...", name.c_str());
+				CMF_LOG(FileArchive, LogLevel::Error, "Too big filename; %s...", name.c_str());
 				abort();
 			}
 
@@ -47,7 +47,7 @@ FileArchive::FileArchive(File file, const std::unordered_set<std::string>& exclu
 	externalData = false;
 
 	if(data == nullptr){
-		ESP_LOGW(TAG, "Failed allocating data buffer of %zu B", totalSize);
+		CMF_LOG(FileArchive, LogLevel::Warning, "Failed allocating data buffer of %zu B", totalSize);
 		return;
 	}
 

--- a/src/FileSystem/RamFile.cpp
+++ b/src/FileSystem/RamFile.cpp
@@ -1,13 +1,13 @@
 #include "RamFile.h"
+#include "Log/Log.h"
 #include <cstring>
-#include <esp_log.h>
 #include <esp_heap_caps.h>
 
-static const char* TAG = "RamFile";
+DEFINE_LOG(RamFile)
 
 RamFile::RamFile(File file, bool use32bAligned) : filePath(file.name()){
 	if(!file){
-		ESP_LOGE(TAG, "Couldn't open file: %s", file.name());
+		CMF_LOG(RamFile, LogLevel::Error, "Couldn't open file: %s", file.name());
 		return;
 	}
 
@@ -15,7 +15,7 @@ RamFile::RamFile(File file, bool use32bAligned) : filePath(file.name()){
 	fileSize = file.size();
 
 	if(fileSize == 0){
-		ESP_LOGE(TAG, "File is empty: %s", file.name());
+		CMF_LOG(RamFile, LogLevel::Error, "File is empty: %s", file.name());
 		file.close();
 		return;
 	}
@@ -30,7 +30,7 @@ RamFile::RamFile(File file, bool use32bAligned) : filePath(file.name()){
 	data = (uint8_t*) heap_caps_malloc(allocSize, MALLOC_CAP_INTERNAL | (use32bAligned ? MALLOC_CAP_32BIT : MALLOC_CAP_8BIT));
 	if(data == nullptr){
 		fileSize = 0;
-		ESP_LOGE(TAG, "Couldn't allocate memory for %s. Need %zu B, largest block: %zu B", file.name(), allocSize,
+		CMF_LOG(RamFile, LogLevel::Error, "Couldn't allocate memory for %s. Need %zu B, largest block: %zu B", file.name(), allocSize,
 				 heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | (use32bAligned ? MALLOC_CAP_32BIT : MALLOC_CAP_8BIT)));
 		file.close();
 

--- a/src/FileSystem/RawCache.cpp
+++ b/src/FileSystem/RawCache.cpp
@@ -1,7 +1,9 @@
-#include <esp_log.h>
+#include "Log/Log.h"
 #include "RawCache.h"
 #include "SPIFFS.h"
 #include "RamFile.h"
+
+DEFINE_LOG(RawCache)
 
 RawCache::RawCache(){ }
 
@@ -26,7 +28,7 @@ void RawCache::load(){
 	for(const auto& path : paths){
 		File file = SPIFFS::open(path.c_str());
 		if(!file){
-			ESP_LOGW("RawCache", "Can't open file %s", path.c_str());
+			CMF_LOG(RawCache, LogLevel::Warning, "Can't open file %s", path.c_str());
 			continue;
 		}
 

--- a/src/FileSystem/SPIFFS.cpp
+++ b/src/FileSystem/SPIFFS.cpp
@@ -1,9 +1,9 @@
 #include "SPIFFS.h"
 #include "FSFileImpl.h"
+#include "Log/Log.h"
 #include <esp_spiffs.h>
-#include <esp_log.h>
 
-static const char* TAG = "SPIFFS";
+DEFINE_LOG(SPIFFS)
 
 bool SPIFFS::inited = false;
 
@@ -21,11 +21,11 @@ bool SPIFFS::init(){
 	auto ret = esp_vfs_spiffs_register(&conf);
 	if(ret != ESP_OK){
 		if(ret == ESP_FAIL){
-			ESP_LOGE(TAG, "Failed to mount or format filesystem");
+			CMF_LOG(SPIFFS, LogLevel::Error, "Failed to mount or format filesystem");
 		}else if(ret == ESP_ERR_NOT_FOUND){
-			ESP_LOGE(TAG, "Failed to find SPIFFS partition");
+			CMF_LOG(SPIFFS, LogLevel::Error, "Failed to find SPIFFS partition");
 		}else{
-			ESP_LOGE(TAG, "Failed to initialize SPIFFS (%s)", esp_err_to_name(ret));
+			CMF_LOG(SPIFFS, LogLevel::Error, "Failed to initialize SPIFFS (%s)", esp_err_to_name(ret));
 		}
 		return false;
 	}

--- a/src/LV_Interface/FSLVGL.cpp
+++ b/src/LV_Interface/FSLVGL.cpp
@@ -1,12 +1,13 @@
 #include "FSLVGL.h"
 #include "FileSystem/SPIFFS.h"
+#include "Log/Log.h"
 #include <dirent.h>
 #include <esp_spiffs.h>
 #include <string>
 #include <unordered_map>
 #include <cstring>
 
-const char* TAG = "FSLVGL";
+DEFINE_LOG(FSLVGL)
 
 FSLVGL* FSLVGL::instance = nullptr;
 
@@ -74,6 +75,7 @@ void* FSLVGL::lvOpen(const char* path, lv_fs_mode_t mode){
 	file = SPIFFS::open(path, Map.at(mode));
 	if(file) return mkPtr(file);
 
+	CMF_LOG(FSLVGL, LogLevel::Warning, "Failed to open '%s' from cache or SPIFFS", path);
 	return nullptr;
 }
 

--- a/src/LV_Interface/LVGIF.cpp
+++ b/src/LV_Interface/LVGIF.cpp
@@ -1,9 +1,9 @@
 #include <string>
 #include <cstdio>
-#include <esp_log.h>
+#include "Log/Log.h"
 #include "LVGIF.h"
 
-static const char* tag = "LVGIF";
+DEFINE_LOG(LVGIF)
 
 LVGIF::LVGIF(lv_obj_t* parent, const char* path) : LVObject(parent), path(path){
 	auto strpath = std::string(path);
@@ -17,7 +17,7 @@ LVGIF::LVGIF(lv_obj_t* parent, const char* path) : LVObject(parent), path(path){
 	auto f = fopen(descPath.c_str(), "r");
 
 	if(f == nullptr){
-		ESP_LOGE(tag, "Couldn't open GIF descriptor file at %s", descPath.c_str());
+		CMF_LOG(LVGIF, LogLevel::Error, "Couldn't open GIF descriptor file at %s", descPath.c_str());
 		return;
 	}
 

--- a/src/LV_Interface/LVGL.cpp
+++ b/src/LV_Interface/LVGL.cpp
@@ -1,12 +1,14 @@
 #include "LVGL.h"
 #include "InputLVGL.h"
-#include <esp_log.h>
+#include "Log/Log.h"
 #include <core/lv_global.h>
 #include <draw/lv_image_decoder.h>
 #include <draw/lv_image_decoder_private.h>
 #include <draw/sw/blend/lv_draw_sw_blend_to_rgb565.h>
 #include <draw/sw/blend/lv_draw_sw_blend_private.h>
 #include <themes/lv_theme_private.h>
+
+DEFINE_LOG(LVGL)
 
 void LVGL::__postInitProperties() noexcept {
 	// Thread is not started automatically; call startThread() after startScreen().
@@ -105,7 +107,7 @@ void LVGL::drawImage(const char* src){
 	const lv_image_decoder_args_t args = { .no_cache = true };
 	lv_result_t res = lv_image_decoder_open(&decoder, src, &args);
 	if(res != LV_RESULT_OK){
-		ESP_LOGE("LVGL::drawImage", "Failed opening image file %s", src);
+		CMF_LOG(LVGL, LogLevel::Error, "drawImage: Failed opening image file %s", src);
 		return;
 	}
 

--- a/src/LV_Interface/LVScreen.cpp
+++ b/src/LV_Interface/LVScreen.cpp
@@ -1,11 +1,11 @@
 #include "LVScreen.h"
 #include "LVGL.h"
 #include "InputLVGL.h"
+#include "Log/Log.h"
 #include <cstdio>
 #include <utility>
-#include <esp_log.h>
 
-static constexpr const char* TAG = "LVScreen";
+DEFINE_LOG(LVScreen)
 
 LVScreen::LVScreen() : LVObject(nullptr){
 
@@ -21,7 +21,7 @@ LVScreen::LVScreen() : LVObject(nullptr){
 
 LVScreen::~LVScreen(){
 	if(running){
-		ESP_LOGE(TAG, "Destroying while still running! Call stop() first.");
+		CMF_LOG(LVScreen, LogLevel::Error, "Destroying while still running! Call stop() first.");
 		abort();
 	}
 	lv_group_delete(inputGroup);
@@ -29,7 +29,7 @@ LVScreen::~LVScreen(){
 
 void LVScreen::transition(std::function<std::unique_ptr<LVScreen>()> create, lv_screen_load_anim_t anim){
 	if(lvgl == nullptr){
-		ESP_LOGE(TAG, "Starting transition, but LVGL ptr isn't set");
+		CMF_LOG(LVScreen, LogLevel::Error, "Starting transition, but LVGL ptr isn't set");
 		abort();
 	}
 	lvgl->startScreen(std::move(create), anim);
@@ -38,7 +38,7 @@ void LVScreen::transition(std::function<std::unique_ptr<LVScreen>()> create, lv_
 void LVScreen::start(LVGL* lvgl){
 	this->lvgl = lvgl;
 	if(running){
-		printf("Already running\n");
+		CMF_LOG(LVScreen, LogLevel::Warning, "start() called while already running");
 		return;
 	}
 	onStarting();

--- a/src/Object/Class.cpp
+++ b/src/Object/Class.cpp
@@ -1,5 +1,6 @@
 #include "Class.h"
 #include "Object.h"
+#include "Log/Log.h"
 #include "Memory/SmartPtr/StrongObjectPtr.h"
 
 const Class* ClassRegistry::getClass(uint64_t ID) const noexcept{
@@ -41,6 +42,7 @@ Class::Class(uint64_t ID) noexcept : classID(ID) {
 StrongObjectPtr<Object> Class::__createObject(void* arguments) const noexcept {
 	void* temp = operator new(sizeof(Object));
 	if(temp == nullptr){
+		CMF_LOG(CMF, LogLevel::Error, "Class::__createObject: out of memory allocating Object (%zu B)", sizeof(Object));
 		return nullptr;
 	}
 

--- a/src/Periphery/I2CMaster.cpp
+++ b/src/Periphery/I2CMaster.cpp
@@ -3,12 +3,16 @@
 #include <Log/Log.h>
 #include <driver/i2c_master.h>
 
+DEFINE_LOG(I2CMaster)
+
 I2CMaster::I2CMaster(I2CPort port, gpio_num_t sda, gpio_num_t scl) noexcept : Super(), port(i2c_port_t(port)){
 	if(port == I2CPort::None){
+		CMF_LOG(I2CMaster, LogLevel::Error, "I2CMaster constructed with port=None, instance is unusable");
 		return;
 	}
 
 	if(sda == GPIO_NUM_NC || scl == GPIO_NUM_NC){
+		CMF_LOG(I2CMaster, LogLevel::Error, "I2CMaster constructed without SDA/SCL pins (sda=%d, scl=%d), instance is unusable", (int) sda, (int) scl);
 		return;
 	}
 
@@ -35,7 +39,10 @@ std::lock_guard<std::mutex> I2CMaster::lockBus() noexcept{
 }
 
 std::unique_ptr<I2CDevice> I2CMaster::addDevice(uint16_t addr, i2c_addr_bit_len_t addrLen, uint32_t speedHz){
-	if(probe(addr) != ESP_OK) return {};
+	if(const auto err = probe(addr); err != ESP_OK){
+		CMF_LOG(I2CMaster, LogLevel::Warning, "addDevice: probe failed for address 0x%x: %s", addr, esp_err_to_name(err));
+		return {};
+	}
 
 	const i2c_device_config_t cfg = {
 			.dev_addr_length = addrLen,
@@ -44,7 +51,8 @@ std::unique_ptr<I2CDevice> I2CMaster::addDevice(uint16_t addr, i2c_addr_bit_len_
 	};
 
 	i2c_master_dev_handle_t devHndl;
-	if(i2c_master_bus_add_device(hndl, &cfg, &devHndl) != ESP_OK) {
+	if(const auto err = i2c_master_bus_add_device(hndl, &cfg, &devHndl); err != ESP_OK){
+		CMF_LOG(I2CMaster, LogLevel::Error, "addDevice: i2c_master_bus_add_device failed for address 0x%x: %s", addr, esp_err_to_name(err));
 		return {};
 	}
 
@@ -52,15 +60,15 @@ std::unique_ptr<I2CDevice> I2CMaster::addDevice(uint16_t addr, i2c_addr_bit_len_
 }
 
 void I2CMaster::scan(TickType_t timeout) noexcept{
-	printf("I2C scan:\n");
+	CMF_LOG(I2CMaster, LogLevel::Info, "I2C scan:");
 
 	for(size_t i = 0; i < 127; ++i){
 		if(probe(i, timeout) == ESP_OK){
-			printf("Found device on address 0x%x\n", i);
+			CMF_LOG(I2CMaster, LogLevel::Info, "Found device on address 0x%x", (unsigned) i);
 		}
 	}
 
-	printf("I2C scan done.\n");
+	CMF_LOG(I2CMaster, LogLevel::Info, "I2C scan done.");
 }
 
 esp_err_t I2CMaster::probe(uint8_t address, TickType_t timeout) noexcept{

--- a/src/Periphery/I2S.cpp
+++ b/src/Periphery/I2S.cpp
@@ -1,6 +1,7 @@
 #include "I2S.h"
+#include "Log/Log.h"
 
-static constexpr const char* TAG = "I2S";
+DEFINE_LOG(I2S)
 
 I2S::I2S(i2s_port_t port, i2s_std_config_t config){
 	i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(port, I2S_ROLE_MASTER);
@@ -34,28 +35,34 @@ I2S::~I2S(){
 
 size_t I2S::write(uint8_t* data, size_t bytes){
 	if(!tx_chan){
-		ESP_LOGE(TAG, "No TX channel configured!");
+		CMF_LOG(I2S, LogLevel::Error, "No TX channel configured!");
 		return ESP_ERR_INVALID_STATE;
 	}
 
 	size_t bytesWritten = 0;
 	auto err = i2s_channel_write(tx_chan, data, bytes, &bytesWritten, portMAX_DELAY);
 
-	if(err != ESP_OK) return 0;
+	if(err != ESP_OK){
+		CMF_LOG(I2S, LogLevel::Warning, "i2s_channel_write failed: %s", esp_err_to_name(err));
+		return 0;
+	}
 
 	return bytesWritten;
 }
 
 size_t I2S::read(uint8_t* data, size_t bytes){
 	if(!rx_chan){
-		ESP_LOGE(TAG, "No RX channel configured!");
+		CMF_LOG(I2S, LogLevel::Error, "No RX channel configured!");
 		return 0;
 	}
 
 	size_t bytesRead = 0;
 	auto err = i2s_channel_read(rx_chan, data, bytes, &bytesRead, portMAX_DELAY);
 
-	if(err != ESP_OK) return 0;
+	if(err != ESP_OK){
+		CMF_LOG(I2S, LogLevel::Warning, "i2s_channel_read failed: %s", esp_err_to_name(err));
+		return 0;
+	}
 
 	return (int32_t) bytesRead;
 }

--- a/src/Periphery/WiFi.cpp
+++ b/src/Periphery/WiFi.cpp
@@ -376,6 +376,9 @@ void WiFi::createNetif() const noexcept {
         cfg.base = &base;
 
         esp_netif_t* netif = esp_netif_new(&cfg);
+        if(netif == nullptr){
+            CMF_LOG(WiFi, LogLevel::Error, "esp_netif_new returned nullptr for WiFi access point");
+        }
         assert(netif);
         esp_netif_set_default_netif(netif);
 
@@ -397,6 +400,9 @@ void WiFi::createNetif() const noexcept {
         cfg.base = &base;
 
         esp_netif_t* netif = esp_netif_new(&cfg);
+        if(netif == nullptr){
+            CMF_LOG(WiFi, LogLevel::Error, "esp_netif_new returned nullptr for WiFi station");
+        }
         assert(netif);
         esp_netif_set_default_netif(netif);
 

--- a/src/Services/Audio/Audio.cpp
+++ b/src/Services/Audio/Audio.cpp
@@ -160,6 +160,7 @@ void Audio::tick(float deltaTime) noexcept{
 	Super::tick(deltaTime);
 
 	if(!xSemaphoreTake(tickSemaphore, portMAX_DELAY)){
+		CMF_LOG(Audio, LogLevel::Warning, "tick: failed to take tickSemaphore");
 		return;
 	}
 
@@ -205,6 +206,7 @@ void Audio::internalStop(){
 	}
 
 	if(!xSemaphoreTake(tickSemaphore, portMAX_DELAY)){
+		CMF_LOG(Audio, LogLevel::Warning, "internalStop: failed to take tickSemaphore");
 		return;
 	}
 

--- a/src/Services/Modules/ModuleDevices/RM_LEDModule.cpp
+++ b/src/Services/Modules/ModuleDevices/RM_LEDModule.cpp
@@ -1,4 +1,7 @@
 #include "RM_LEDModule.h"
+#include "Log/Log.h"
+
+DEFINE_LOG(RM_LEDModule)
 
 RM_LEDModule::RM_LEDModule(const Modules::BusPins& busPins) : Super(Modules::Type::RM_LED, busPins){
 	set(false);
@@ -9,8 +12,10 @@ void RM_LEDModule::set(bool state){
 }
 
 void RM_LEDModule::setLevel(float level){
-	ESP_LOGI("RM_LEDModule", "Setting LED level to %.2f", level);
+	CMF_LOG(RM_LEDModule, LogLevel::Info, "Setting LED level to %.2f", level);
 	if(pins.subAddressPins[0].outputDriver){
 		pins.subAddressPins[0].outputDriver->write(pins.subAddressPins[0].port, level);
+	}else{
+		CMF_LOG(RM_LEDModule, LogLevel::Warning, "No output driver assigned for LED module pin");
 	}
 }

--- a/src/Services/Modules/ModuleService.h
+++ b/src/Services/Modules/ModuleService.h
@@ -3,12 +3,15 @@
 
 #include <map>
 #include "Entity/AsyncEntity.h"
+#include "Log/Log.h"
 #include "ModuleType.h"
 #include "Event/EventBroadcaster.h"
 #include "Drivers/Interface/InputDriver.h"
 #include "Drivers/Interface/OutputDriver.h"
 #include "ModuleDevice.h"
 #include "ModuleDefs.h"
+
+DEFINE_LOG(ModuleService)
 
 /**
 * Service for managing UMAX modules (https://www.lcsc.com/datasheet/C404108.pdf)
@@ -104,7 +107,7 @@ private:
 
 			busContexts[bus].type = Modules::Type::Unknown;
 
-			ESP_LOGI(TAG, "Module %d removed from bus %d", (int) removed, bus);
+			CMF_LOG(ModuleService, LogLevel::Info, "Module %d removed from bus %d", (int) removed, bus);
 			ModulesEvent.broadcast(bus, removed, Action::Remove);
 
 			busContexts[bus].instance = nullptr;
@@ -116,7 +119,7 @@ private:
 			busContexts[bus].type = type;
 			busContexts[bus].inserted = true;
 
-			ESP_LOGI(TAG, "Module %d inserted into bus %d", (int) type, bus);
+			CMF_LOG(ModuleService, LogLevel::Info, "Module %d inserted into bus %d", (int) type, bus);
 			ModulesEvent.broadcast(bus, type, Action::Insert);
 
 			if(type != Modules::Type::Unknown){
@@ -149,7 +152,7 @@ private:
 			}
 		}
 
-		ESP_LOGI(TAG, "primary address %d", addr);
+		CMF_LOG(ModuleService, LogLevel::Info, "primary address %d", addr);
 
 		readAddress.mainAddress = addr;
 
@@ -158,7 +161,7 @@ private:
 			if(AddressMap.contains(readAddress)){
 				return AddressMap.at(readAddress);
 			}else{
-				ESP_LOGW(TAG, "Unknown primary address");
+				CMF_LOG(ModuleService, LogLevel::Warning, "Unknown primary address");
 				return Modules::Type::Unknown;
 			}
 		}
@@ -223,14 +226,14 @@ private:
 		}
 
 		if(readSubAddress.type == Modules::SubAddress::Type::None){
-			ESP_LOGW(TAG, "Unknown main-sub address combination");
+			CMF_LOG(ModuleService, LogLevel::Warning, "Unknown main-sub address combination");
 			return Modules::Type::Unknown;
 		}
 
 		readAddress.subAddress = readSubAddress;
 
 		if(!AddressMap.contains(readAddress)){
-			ESP_LOGE(TAG, "Error in main/sub address mapping (internal error)");
+			CMF_LOG(ModuleService, LogLevel::Error, "Error in main/sub address mapping (internal error)");
 			return Modules::Type::Unknown;
 		}
 
@@ -305,8 +308,6 @@ private:
 			}
 		}
 	}
-
-	static constexpr const char* TAG = "ModuleService";
 };
 
 

--- a/src/Services/Motors/Motors.h
+++ b/src/Services/Motors/Motors.h
@@ -86,7 +86,10 @@ public:
 	void dereg(Motor motor){
 		std::lock_guard guard(accessMutex);
 
-		if(!motorPins.count(motor)) return;
+		if(!motorPins.count(motor)){
+			CMF_LOG(Motors, LogLevel::Warning, "dereg called for motor %d, but motor is not registered", static_cast<int>(motor));
+			return;
+		}
 
 		motorPins[motor].digitalPin.driver->write(motorPins[motor].digitalPin.port, false);
 		motorPins[motor].analogPin.driver->write(motorPins[motor].analogPin.port, false);

--- a/src/Services/Motors/Servos.h
+++ b/src/Services/Motors/Servos.h
@@ -63,13 +63,19 @@ public:
 	}
 
 	float get(Servo servo){
-		if(!currentValues.count(servo)) return 0;
+		if(!currentValues.count(servo)){
+			CMF_LOG(Servos, LogLevel::Warning, "get called for unregistered servo");
+			return 0;
+		}
 
 		return currentValues[servo];
 	}
 
 	void enable(Servo servo){
-		if(!pins.count(servo)) return;
+		if(!pins.count(servo)){
+			CMF_LOG(Servos, LogLevel::Warning, "Servo not registered");
+			return;
+		}
 
 		const auto& pin = pins[servo];
 
@@ -83,7 +89,10 @@ public:
 	}
 
 	void disable(Servo servo){
-		if(!pins.count(servo)) return;
+		if(!pins.count(servo)){
+			CMF_LOG(Servos, LogLevel::Warning, "Servo not registered");
+			return;
+		}
 
 		const auto& pin = pins[servo];
 

--- a/src/Thread/Threaded.cpp
+++ b/src/Thread/Threaded.cpp
@@ -67,10 +67,16 @@ void Threaded::start() noexcept{
 
 	if(core == -1){
 		const auto ret = xTaskCreate(function, name.c_str(), stackSize, this, priority, &task);
-		assert(ret == pdPASS);
+		if(ret != pdPASS){
+			CMF_LOG(CMF, LogLevel::Error, "xTaskCreate failed for thread '%s' (ret=%d)", name.c_str(), (int) ret);
+			assert(ret == pdPASS);
+		}
 	}else{
 		const auto ret = xTaskCreatePinnedToCore(function, name.c_str(), stackSize, this, priority, &task, core);
-		assert(ret == pdPASS);
+		if(ret != pdPASS){
+			CMF_LOG(CMF, LogLevel::Error, "xTaskCreatePinnedToCore failed for thread '%s' on core %d (ret=%d)", name.c_str(), (int) core, (int) ret);
+			assert(ret == pdPASS);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Migrated all direct `ESP_LOG*` usages in `src/` to the framework's `CMF_LOG` macro (`Log/Log.h`), declaring per-subsystem tags with `DEFINE_LOG(...)` instead of file-local `static const char* TAG`.
- Added `CMF_LOG` calls at previously silent failure paths: nullptr checks in constructors and registration helpers, `esp_err_t` returns that were dropped, semaphore-take failures with `portMAX_DELAY`, `xTaskCreate*` failures, OOM in `Class::__createObject`, missing pin/threshold maps, and `esp_netif_new` returning null in `WiFi`.
- Removed unused TAG string literals and the corresponding `#include <esp_log.h>` lines (only `Log/Log.h` retains it now).

## Files touched

- `Devices/`: AW9523, BM8563, Camera, LIS2DW12, TCA9555, Timer
- `Drivers/Input/`, `Drivers/Output/`: InputGPIO, InputTouchGPIO, OutputPWM
- `FileSystem/`: ArchiveCache, FSFileImpl, FileArchive, RamFile, RawCache, SPIFFS
- `LV_Interface/`: FSLVGL, LVGIF, LVGL, LVScreen
- `Periphery/`: I2CMaster, I2S, WiFi
- `Services/`: Audio, Modules/ModuleService, Modules/ModuleDevices/RM_LEDModule, Motors/Motors, Motors/Servos
- `Core/Application.{h,cpp}`, `Object/Class.cpp`, `Thread/Threaded.cpp`

## Notes

- The CMF logging macros wrap ESP-IDF logging internally, so existing log levels controlled via `sdkconfig` continue to work as before.
- Silent-fail logs were added selectively where the failure indicates a real problem (resource acquisition, registration, hardware probe). Routine "not enabled / not playing" early returns and parameter range checks were left as-is to avoid noise.

## Test plan

- [x] Built CMF as a managed component in a minimal IDF v5.5.3 test app for `esp32s3` with default Kconfig — succeeds.
- [x] Built again with `CMF_WIFI`, `CMF_AUDIO`, `CMF_MODULES`, and all `RM_*` module flags enabled — succeeds, no new warnings introduced by these changes.