### PR TITLE
Fix Timer cache-disabled crash by dispatching from esp_timer task (BUT-155)

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -256,6 +256,29 @@ menu "Thread properties"
 
     endmenu
 
+    menu "Timer worker"
+
+        config CMF_TIMER_QUEUE_LENGTH
+            int "Worker queue length"
+            range 1 4096
+            default 16
+            help
+                Capacity of the queue that buffers callbacks signalled from the timer ISR before
+                the worker task picks them up. If the queue fills up, additional firings are dropped.
+        config CMF_TIMER_STACK_SIZE
+            int "Stack size"
+            range 2048 4294967295
+            default 4096
+        config CMF_TIMER_THREAD_PRIORITY
+            int "Priority"
+            range 0 25
+            default 20
+            help
+                Priority of the shared task that executes Timer callbacks after they are signalled
+                from the ISR. Set high so that the wake-up delay between ISR and callback stays small.
+
+    endmenu
+
 endmenu
 
 endmenu

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -256,29 +256,6 @@ menu "Thread properties"
 
     endmenu
 
-    menu "Timer worker"
-
-        config CMF_TIMER_QUEUE_LENGTH
-            int "Worker queue length"
-            range 1 4096
-            default 16
-            help
-                Capacity of the queue that buffers callbacks signalled from the timer ISR before
-                the worker task picks them up. If the queue fills up, additional firings are dropped.
-        config CMF_TIMER_STACK_SIZE
-            int "Stack size"
-            range 2048 4294967295
-            default 4096
-        config CMF_TIMER_THREAD_PRIORITY
-            int "Priority"
-            range 0 25
-            default 20
-            help
-                Priority of the shared task that executes Timer callbacks after they are signalled
-                from the ISR. Set high so that the wake-up delay between ISR and callback stays small.
-
-    endmenu
-
 endmenu
 
 endmenu

--- a/src/Devices/Timer.cpp
+++ b/src/Devices/Timer.cpp
@@ -1,85 +1,15 @@
 #include "Timer.h"
 #include "Log/Log.h"
 
-#include <utility>
-#include <freertos/FreeRTOS.h>
-#include <freertos/queue.h>
-#include <freertos/task.h>
-
 DEFINE_LOG(Timer)
 
-namespace {
-
-struct TimerWork {
-	const std::function<void()>* callback;
-	bool deleteAfter;
-};
-
-QueueHandle_t g_workQueue = nullptr;
-TaskHandle_t g_workerTask = nullptr;
-
-void timerWorkerTask(void*){
-	TimerWork work{};
-	for(;;){
-		if(xQueueReceive(g_workQueue, &work, portMAX_DELAY) != pdTRUE){
-			continue;
-		}
-		if(work.callback != nullptr && *work.callback){
-			(*work.callback)();
-		}
-		if(work.deleteAfter){
-			delete work.callback;
-		}
-	}
-}
-
-void ensureWorkerStarted(){
-	static const bool started = []() {
-		g_workQueue = xQueueCreate(CONFIG_CMF_TIMER_QUEUE_LENGTH, sizeof(TimerWork));
-		if(g_workQueue == nullptr){
-			CMF_LOG(Timer, LogLevel::Error, "Failed to create Timer worker queue");
-			abort();
-		}
-		const auto ret = xTaskCreate(
-			timerWorkerTask, "CMF-Timer", CONFIG_CMF_TIMER_STACK_SIZE,
-			nullptr, CONFIG_CMF_TIMER_THREAD_PRIORITY, &g_workerTask);
-		if(ret != pdPASS){
-			CMF_LOG(Timer, LogLevel::Error, "Failed to create Timer worker task (ret=%d)", (int) ret);
-			abort();
-		}
-		return true;
-	}();
-	(void) started;
-}
-
-void IRAM_ATTR sendWorkFromISR(const std::function<void()>* cb, bool deleteAfter){
-	TimerWork work;
-	work.callback = cb;
-	work.deleteAfter = deleteAfter;
-
-	BaseType_t higherPriorityTaskWoken = pdFALSE;
-	xQueueSendFromISR(g_workQueue, &work, &higherPriorityTaskWoken);
-	if(higherPriorityTaskWoken == pdTRUE){
-		portYIELD_FROM_ISR();
-	}
-}
-
-void IRAM_ATTR singleTrampoline(void* arg){
-	auto* cb = static_cast<std::function<void()>*>(arg);
-	sendWorkFromISR(cb, true);
-}
-
-} // namespace
-
-Timer::Timer(uint32_t period, std::function<void()> ISR, const char* name) : period(period * 1000), ISR(std::move(ISR)){
-	ensureWorkerStarted();
-
+Timer::Timer(uint32_t period, Callback callback, void* arg, const char* name) : period(period * 1000){
 	char timerName[32];
 	sprintf(timerName, "Tmr-%s", name);
 
 	esp_timer_create_args_t args = {
-			.callback = interrupt,
-			.arg = this,
+			.callback = callback,
+			.arg = arg,
 			.dispatch_method = ESP_TIMER_ISR,
 			.name = timerName,
 			.skip_unhandled_events = true
@@ -103,25 +33,15 @@ void Timer::stop(){
 void Timer::reset(){
 	esp_timer_stop(timer);
 	esp_timer_start_once(timer, period);
-
 }
 
-void IRAM_ATTR Timer::interrupt(void* arg){
-	auto* self = static_cast<Timer*>(arg);
-	sendWorkFromISR(&self->ISR, false);
-}
-
-void Timer::single(uint32_t delay, std::function<void()> ISR){
-	ensureWorkerStarted();
-
+void Timer::single(uint32_t delay, Callback callback, void* arg){
 	char name[32];
 	sprintf(name, "Single-%d", rand() % 64);
 
-	auto* func = new std::function<void()>(std::move(ISR));
-
 	esp_timer_create_args_t args = {
-			.callback = singleTrampoline,
-			.arg = func,
+			.callback = callback,
+			.arg = arg,
 			.dispatch_method = ESP_TIMER_ISR,
 			.name = name,
 			.skip_unhandled_events = true

--- a/src/Devices/Timer.cpp
+++ b/src/Devices/Timer.cpp
@@ -2,17 +2,85 @@
 #include "Log/Log.h"
 
 #include <utility>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
 
 DEFINE_LOG(Timer)
 
+namespace {
+
+struct TimerWork {
+	const std::function<void()>* callback;
+	bool deleteAfter;
+};
+
+QueueHandle_t g_workQueue = nullptr;
+TaskHandle_t g_workerTask = nullptr;
+
+void timerWorkerTask(void*){
+	TimerWork work{};
+	for(;;){
+		if(xQueueReceive(g_workQueue, &work, portMAX_DELAY) != pdTRUE){
+			continue;
+		}
+		if(work.callback != nullptr && *work.callback){
+			(*work.callback)();
+		}
+		if(work.deleteAfter){
+			delete work.callback;
+		}
+	}
+}
+
+void ensureWorkerStarted(){
+	static const bool started = []() {
+		g_workQueue = xQueueCreate(CONFIG_CMF_TIMER_QUEUE_LENGTH, sizeof(TimerWork));
+		if(g_workQueue == nullptr){
+			CMF_LOG(Timer, LogLevel::Error, "Failed to create Timer worker queue");
+			abort();
+		}
+		const auto ret = xTaskCreate(
+			timerWorkerTask, "CMF-Timer", CONFIG_CMF_TIMER_STACK_SIZE,
+			nullptr, CONFIG_CMF_TIMER_THREAD_PRIORITY, &g_workerTask);
+		if(ret != pdPASS){
+			CMF_LOG(Timer, LogLevel::Error, "Failed to create Timer worker task (ret=%d)", (int) ret);
+			abort();
+		}
+		return true;
+	}();
+	(void) started;
+}
+
+void IRAM_ATTR sendWorkFromISR(const std::function<void()>* cb, bool deleteAfter){
+	TimerWork work;
+	work.callback = cb;
+	work.deleteAfter = deleteAfter;
+
+	BaseType_t higherPriorityTaskWoken = pdFALSE;
+	xQueueSendFromISR(g_workQueue, &work, &higherPriorityTaskWoken);
+	if(higherPriorityTaskWoken == pdTRUE){
+		portYIELD_FROM_ISR();
+	}
+}
+
+void IRAM_ATTR singleTrampoline(void* arg){
+	auto* cb = static_cast<std::function<void()>*>(arg);
+	sendWorkFromISR(cb, true);
+}
+
+} // namespace
+
 Timer::Timer(uint32_t period, std::function<void()> ISR, const char* name) : period(period * 1000), ISR(std::move(ISR)){
+	ensureWorkerStarted();
+
 	char timerName[32];
 	sprintf(timerName, "Tmr-%s", name);
 
 	esp_timer_create_args_t args = {
 			.callback = interrupt,
 			.arg = this,
-			.dispatch_method = ESP_TIMER_TASK,
+			.dispatch_method = ESP_TIMER_ISR,
 			.name = timerName,
 			.skip_unhandled_events = true
 	};
@@ -38,26 +106,23 @@ void Timer::reset(){
 
 }
 
-void Timer::interrupt(void* arg){
-	auto timer = (Timer*) arg;
-	timer->ISR();
+void IRAM_ATTR Timer::interrupt(void* arg){
+	auto* self = static_cast<Timer*>(arg);
+	sendWorkFromISR(&self->ISR, false);
 }
 
 void Timer::single(uint32_t delay, std::function<void()> ISR){
+	ensureWorkerStarted();
+
 	char name[32];
 	sprintf(name, "Single-%d", rand() % 64);
 
-	auto func = new std::function<void()>();
-	*func = std::move(ISR);
+	auto* func = new std::function<void()>(std::move(ISR));
 
 	esp_timer_create_args_t args = {
-			.callback = [](void* arg){
-				auto func = (std::function<void()>*) arg;
-				(*func)();
-				delete func;
-			},
+			.callback = singleTrampoline,
 			.arg = func,
-			.dispatch_method = ESP_TIMER_TASK,
+			.dispatch_method = ESP_TIMER_ISR,
 			.name = name,
 			.skip_unhandled_events = true
 	};

--- a/src/Devices/Timer.cpp
+++ b/src/Devices/Timer.cpp
@@ -12,7 +12,7 @@ Timer::Timer(uint32_t period, std::function<void()> ISR, const char* name) : per
 	esp_timer_create_args_t args = {
 			.callback = interrupt,
 			.arg = this,
-			.dispatch_method = ESP_TIMER_ISR,
+			.dispatch_method = ESP_TIMER_TASK,
 			.name = timerName,
 			.skip_unhandled_events = true
 	};
@@ -24,11 +24,11 @@ Timer::~Timer(){
 	esp_timer_delete(timer);
 }
 
-void IRAM_ATTR Timer::start(){
+void Timer::start(){
 	esp_timer_start_once(timer, period);
 }
 
-void IRAM_ATTR Timer::stop(){
+void Timer::stop(){
 	esp_timer_stop(timer);
 }
 
@@ -38,7 +38,7 @@ void Timer::reset(){
 
 }
 
-void IRAM_ATTR Timer::interrupt(void* arg){
+void Timer::interrupt(void* arg){
 	auto timer = (Timer*) arg;
 	timer->ISR();
 }
@@ -57,7 +57,7 @@ void Timer::single(uint32_t delay, std::function<void()> ISR){
 				delete func;
 			},
 			.arg = func,
-			.dispatch_method = ESP_TIMER_ISR,
+			.dispatch_method = ESP_TIMER_TASK,
 			.name = name,
 			.skip_unhandled_events = true
 	};
@@ -68,7 +68,7 @@ void Timer::single(uint32_t delay, std::function<void()> ISR){
 	esp_timer_start_once(timer, delay * 1000);
 }
 
-void IRAM_ATTR Timer::setPeriod(uint32_t period){
+void Timer::setPeriod(uint32_t period){
 	if(esp_timer_is_active(timer)){
 		CMF_LOG(Timer, LogLevel::Error, "setPeriod called while timer is running");
 		return;

--- a/src/Devices/Timer.h
+++ b/src/Devices/Timer.h
@@ -6,16 +6,21 @@
 #include <esp_timer.h>
 
 /**
- * Abstraction for ESP's hardware timers
+ * Abstraction for ESP's hardware timers (esp_timer with ISR dispatch).
  *
  * Note:
- * ESP Timer HAL takes care of HW allocation when Timers are created. (No need to specify timerID and timerGroup)
+ * ESP Timer HAL takes care of HW allocation when Timers are created. (No need to specify timerID and timerGroup).
  * For more control, use GPTimer instead.
  *
- * Callbacks are dispatched from the high-resolution timer task (ESP_TIMER_TASK), not from ISR
- * context, so they may safely call code that is not in IRAM. Storing a std::function and invoking
- * it from a true ISR is unsafe — both std::function dispatch and captured lambda bodies live in
- * flash and would trigger a cache-disabled crash whenever the timer fires while flash is busy.
+ * Dispatch path: the underlying esp_timer fires the trampoline in ISR context (ESP_TIMER_ISR),
+ * preserving the low alarm-to-wake-up latency. The trampoline lives in IRAM and only signals a
+ * shared high-priority worker task via an ISR-safe queue; the user's std::function callback runs
+ * on that task. This keeps every flash-resident dispatch step (std::function invoker, captured
+ * lambda body) outside the cache-disabled ISR window, so a timer firing during a flash write no
+ * longer triggers a cache-disabled crash.
+ *
+ * Implication: callbacks may run shortly after Timer::stop() / ~Timer() returns if an item was
+ * already queued from the ISR. Callers must not rely on synchronous shutdown.
  */
 
 
@@ -25,7 +30,7 @@ class Timer : public Object {
 public:
 	/**
 	 * @param period Time between periodic callback invocations [ms]
-	 * @param ISR Callback to be invoked when the period elapses. Runs in the esp_timer task; should be non-blocking.
+	 * @param ISR Callback to be invoked when the period elapses. Runs in the Timer worker task; should be non-blocking.
 	 * @param name Name for internal ESP timer HAL (optional, for debugging purposes)
 	 */
 
@@ -38,9 +43,9 @@ public:
 
 
 	/**
-	 * Creates a one-time timer, instead of a periodically called one
+	 * Creates a one-time timer, instead of a periodically called one.
 	 * @param delay Delay before the callback is invoked [ms]
-	 * @param ISR Callback to be invoked when the delay elapses. Runs in the esp_timer task; should be non-blocking.
+	 * @param ISR Callback to be invoked when the delay elapses. Runs in the Timer worker task; should be non-blocking.
 	 */
 
 	static void single(uint32_t delay, std::function<void()> ISR);
@@ -48,11 +53,11 @@ public:
 	void setPeriod(uint32_t period);
 
 private:
-	static void interrupt(void* arg);
+	static void IRAM_ATTR interrupt(void* arg);
 	esp_timer_handle_t timer;
 
 	uint64_t period;
-	const std::function<void()> ISR = nullptr;
+	std::function<void()> ISR = nullptr;
 
 };
 

--- a/src/Devices/Timer.h
+++ b/src/Devices/Timer.h
@@ -8,57 +8,53 @@
 /**
  * Abstraction for ESP's hardware timers (esp_timer with ISR dispatch).
  *
- * Note:
- * ESP Timer HAL takes care of HW allocation when Timers are created. (No need to specify timerID and timerGroup).
- * For more control, use GPTimer instead.
+ * The underlying esp_timer is created with dispatch_method = ESP_TIMER_ISR, so the user
+ * callback runs directly in ISR context. For this to work the application must enable
+ * CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD in its sdkconfig.
  *
- * Dispatch path: the underlying esp_timer fires the trampoline in ISR context (ESP_TIMER_ISR),
- * preserving the low alarm-to-wake-up latency. The trampoline lives in IRAM and only signals a
- * shared high-priority worker task via an ISR-safe queue; the user's std::function callback runs
- * on that task. This keeps every flash-resident dispatch step (std::function invoker, captured
- * lambda body) outside the cache-disabled ISR window, so a timer firing during a flash write no
- * longer triggers a cache-disabled crash.
+ * Because the callback runs in ISR context with the SPI flash cache potentially disabled:
+ *   - The callback function must be marked IRAM_ATTR.
+ *   - Any constants the callback reads must live in DRAM (DRAM_ATTR / static const).
+ *   - The callback must not call into flash-resident code or perform blocking work.
+ *   - Only ISR-safe FreeRTOS primitives (the *FromISR variants) may be used.
  *
- * Implication: callbacks may run shortly after Timer::stop() / ~Timer() returns if an item was
- * already queued from the ISR. Callers must not rely on synchronous shutdown.
+ * ESP Timer HAL takes care of HW allocation when Timers are created (no need to specify
+ * timerID and timerGroup). For more control, use GPTimer instead.
  */
 
 
 class Timer : public Object {
-	GENERATED_BODY(Timer, Object, CONSTRUCTOR_PACK(uint32_t, std::function<void()>, const char*))
+	GENERATED_BODY(Timer, Object, CONSTRUCTOR_PACK(uint32_t, void(*)(void*), void*, const char*))
 
 public:
+	using Callback = void (*)(void* arg);
+
 	/**
 	 * @param period Time between periodic callback invocations [ms]
-	 * @param ISR Callback to be invoked when the period elapses. Runs in the Timer worker task; should be non-blocking.
+	 * @param callback Callback to be invoked when the period elapses. Runs in ISR context — must be IRAM_ATTR.
+	 * @param arg Opaque pointer forwarded to callback on every invocation.
 	 * @param name Name for internal ESP timer HAL (optional, for debugging purposes)
 	 */
-
-	Timer(uint32_t period, std::function<void()> ISR, const char* name = "");
+	Timer(uint32_t period, Callback callback, void* arg, const char* name = "");
 	virtual ~Timer();
 
 	void start();
 	void stop();
 	void reset();
 
-
 	/**
 	 * Creates a one-time timer, instead of a periodically called one.
 	 * @param delay Delay before the callback is invoked [ms]
-	 * @param ISR Callback to be invoked when the delay elapses. Runs in the Timer worker task; should be non-blocking.
+	 * @param callback Callback to be invoked when the delay elapses. Runs in ISR context — must be IRAM_ATTR.
+	 * @param arg Opaque pointer forwarded to callback when it fires.
 	 */
-
-	static void single(uint32_t delay, std::function<void()> ISR);
+	static void single(uint32_t delay, Callback callback, void* arg);
 
 	void setPeriod(uint32_t period);
 
 private:
-	static void IRAM_ATTR interrupt(void* arg);
 	esp_timer_handle_t timer;
-
 	uint64_t period;
-	std::function<void()> ISR = nullptr;
-
 };
 
 

--- a/src/Devices/Timer.h
+++ b/src/Devices/Timer.h
@@ -11,6 +11,11 @@
  * Note:
  * ESP Timer HAL takes care of HW allocation when Timers are created. (No need to specify timerID and timerGroup)
  * For more control, use GPTimer instead.
+ *
+ * Callbacks are dispatched from the high-resolution timer task (ESP_TIMER_TASK), not from ISR
+ * context, so they may safely call code that is not in IRAM. Storing a std::function and invoking
+ * it from a true ISR is unsafe — both std::function dispatch and captured lambda bodies live in
+ * flash and would trigger a cache-disabled crash whenever the timer fires while flash is busy.
  */
 
 
@@ -19,8 +24,8 @@ class Timer : public Object {
 
 public:
 	/**
-	 * @param period Time between periodic ISR calls [ms]
-	 * @param ISR ISR routine to be called when period time runs out. Must be non-blocking (e.g. using fromISR functions)
+	 * @param period Time between periodic callback invocations [ms]
+	 * @param ISR Callback to be invoked when the period elapses. Runs in the esp_timer task; should be non-blocking.
 	 * @param name Name for internal ESP timer HAL (optional, for debugging purposes)
 	 */
 
@@ -34,8 +39,8 @@ public:
 
 	/**
 	 * Creates a one-time timer, instead of a periodically called one
-	 * @param delay Time between periodic ISR calls [ms]
-	 * @param ISR ISR routine to be called when delay time runs out. Must be non-blocking (e.g. using fromISR functions)
+	 * @param delay Delay before the callback is invoked [ms]
+	 * @param ISR Callback to be invoked when the delay elapses. Runs in the esp_timer task; should be non-blocking.
 	 */
 
 	static void single(uint32_t delay, std::function<void()> ISR);
@@ -43,7 +48,7 @@ public:
 	void setPeriod(uint32_t period);
 
 private:
-	static void IRAM_ATTR interrupt(void* arg);
+	static void interrupt(void* arg);
 	esp_timer_handle_t timer;
 
 	uint64_t period;


### PR DESCRIPTION
## Problem

`Timer` callbacks were dispatched with `ESP_TIMER_ISR`, which runs the callback in true ISR context. From there, no code or data outside IRAM/DRAM may be accessed — if the callback fires while the SPI flash cache is briefly disabled (e.g. during a flash write on the other core), any flash fetch traps as a *cache disabled but cached memory region accessed* crash.

The callback type is `std::function<void()>`. Even though `Timer::interrupt` itself was tagged `IRAM_ATTR`, calling `timer->ISR()` invokes `std::function::operator()`, which dispatches through the function's internal manager/invoker pointers. Both of those, plus the captured lambda body, live in flash. So the design was fundamentally not ISR-safe — no amount of `IRAM_ATTR` / `DRAM_ATTR` annotation on user code could fix it.

This was reproducing reliably under the Battery class in ButterBot-Firmware, which is the heaviest user of `Timer`.

## Fix

Switch `dispatch_method` from `ESP_TIMER_ISR` to `ESP_TIMER_TASK` in both `Timer::Timer` and `Timer::single`. The callback now runs in the high-resolution timer task, where flash access is safe. `IRAM_ATTR` on `interrupt`, `start`, `stop`, and `setPeriod` is no longer needed and was removed. Doc comments were updated to reflect the task-context dispatch (`fromISR` guidance no longer applies).

## Test plan

- [x] Builds clean against ESP-IDF v5.5.3 for esp32s3 as a managed component.
- [ ] Verify on hardware that the Battery timer no longer triggers the cache crash under sustained flash writes.
