### PR TITLE
Add Kconfig options for EventScanner thread properties (BUT-162)

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -256,6 +256,29 @@ menu "Thread properties"
 
     endmenu
 
+    menu "EventScanner"
+
+        config CMF_EVENTSCANNER_TICK_INTERVAL
+            int "Tick interval"
+            range 0 4294967295
+            default 0
+        config CMF_EVENTSCANNER_STACK_SIZE
+            int "Stack size"
+            range 2048 4294967295
+            default 4096
+        config CMF_EVENTSCANNER_THREAD_PRIORITY
+            int "Priority"
+            range 0 25
+            default 20
+        config CMF_EVENTSCANNER_CPU_CORE
+            int "CPU core"
+            range -1 1
+            default -1
+            help
+                Pin the thread to a CPU core, if -1, it is not pinned but assigned automatically to a free CPU core.
+
+    endmenu
+
 endmenu
 
 endmenu

--- a/src/Event/EventScanner.cpp
+++ b/src/Event/EventScanner.cpp
@@ -1,7 +1,7 @@
 #include "EventScanner.h"
 #include "EventHandle.h"
 
-EventScanner::EventScanner() : Super(0, 4 * 1024, 20) {
+EventScanner::EventScanner() : Super(CONFIG_CMF_EVENTSCANNER_TICK_INTERVAL / portTICK_PERIOD_MS, CONFIG_CMF_EVENTSCANNER_STACK_SIZE, CONFIG_CMF_EVENTSCANNER_THREAD_PRIORITY, CONFIG_CMF_EVENTSCANNER_CPU_CORE) {
     semaphore = xSemaphoreCreateBinary();
 }
 


### PR DESCRIPTION
## Summary

Adds Kconfig options for `EventScanner` thread properties under the existing **CMF → Thread properties** menu, matching the pattern already used for `Application`, `AsyncEntity`, `ButtonInput`, `LED`, `Audio`, `StateMachine`, and `ModuleService`.

New options under `menu "EventScanner"`:
- `CMF_EVENTSCANNER_TICK_INTERVAL` (default `0`)
- `CMF_EVENTSCANNER_STACK_SIZE` (default `4096`)
- `CMF_EVENTSCANNER_THREAD_PRIORITY` (default `20`)
- `CMF_EVENTSCANNER_CPU_CORE` (default `-1`)

Defaults reproduce the previous hardcoded values from `EventScanner::EventScanner()` (`Super(0, 4 * 1024, 20)`), and add a CPU-core option in line with sibling thread classes.

`EventScanner::EventScanner()` now forwards these `CONFIG_*` values to the `AsyncEntity` base constructor (with the standard `/ portTICK_PERIOD_MS` conversion on the tick interval), so callers can tune them through `menuconfig` without code changes.
