### PR TITLE
Heap-allocation reductions via std::array / std::span (CMF-62)

### DIFF
--- a/src/Containers/Archive.cpp
+++ b/src/Containers/Archive.cpp
@@ -1,6 +1,6 @@
 #include "Archive.h"
 
-Archive::Archive(const std::vector<uint8_t>& queue) noexcept {
+Archive::Archive(std::span<const uint8_t> queue) noexcept {
 	for(uint8_t value : queue) {
 		pushDataPoint(value);
 	}
@@ -41,7 +41,7 @@ bool Archive::popDataPoint(uint8_t& data) noexcept {
 	return true;
 }
 
-InArchive::InArchive(const std::vector<uint8_t>& queue) noexcept : Archive(queue) {}
+InArchive::InArchive(std::span<const uint8_t> queue) noexcept : Archive(queue) {}
 
 InArchive::InArchive(const std::queue<uint8_t>& queue) noexcept : Archive(queue) {}
 
@@ -516,7 +516,7 @@ Archive& InArchive::operator << (const std::vector<std::wstring>& data) noexcept
 	return *this;
 }
 
-OutArchive::OutArchive(const std::vector<uint8_t>& queue) noexcept : Archive(queue) {}
+OutArchive::OutArchive(std::span<const uint8_t> queue) noexcept : Archive(queue) {}
 
 OutArchive::OutArchive(const std::queue<uint8_t>& queue) noexcept : Archive(queue) {}
 

--- a/src/Containers/Archive.h
+++ b/src/Containers/Archive.h
@@ -1,9 +1,11 @@
 #ifndef CMF_ARCHIVE_H
 #define CMF_ARCHIVE_H
 
+#include <cstdint>
 #include <queue>
-#include <queue>
+#include <span>
 #include <string>
+#include <vector>
 
 /**
  * @brief The base archive class, functioning as the backbone and implementation of internal works for the in-only and out-only archives.
@@ -17,9 +19,9 @@ public:
 
 	/**
 	 * @brief Constructor from a given byte array.
-	 * @param queue Vector containing the archive data.
+	 * @param queue Span of bytes containing the archive data.
 	 */
-	Archive(const std::vector<uint8_t>& queue) noexcept;
+	Archive(std::span<const uint8_t> queue) noexcept;
 
 	/**
 	 * @brief Constructor from a give byte queue.
@@ -343,10 +345,10 @@ public:
 	InArchive() noexcept = default;
 
 	/**
-	 * @brief Constructor from a vector of byte data treated as a queue.
-	 * @param queue The vector of byte data.
+	 * @brief Constructor from a span of byte data treated as a queue.
+	 * @param queue The span of byte data.
 	 */
-	InArchive(const std::vector<uint8_t>& queue) noexcept;
+	InArchive(std::span<const uint8_t> queue) noexcept;
 
 	/**
 	 * @brief Constructor from a queue of byte data.
@@ -793,10 +795,10 @@ public:
 	OutArchive() noexcept = default;
 
 	/**
-	 * @brief The constructor from a vector of byte date treated as a queue.
-	 * @param queue The vector of byte data.
+	 * @brief The constructor from a span of byte data treated as a queue.
+	 * @param queue The span of byte data.
 	 */
-	OutArchive(const std::vector<uint8_t>& queue) noexcept;
+	OutArchive(std::span<const uint8_t> queue) noexcept;
 
 	/**
 	 * @brief The constructor from a queue of byte data.

--- a/src/Devices/BM8563.cpp
+++ b/src/Devices/BM8563.cpp
@@ -1,6 +1,7 @@
 #include "BM8563.h"
 #include "Log/Log.h"
 #include "Periphery/I2CMaster.h"
+#include <array>
 
 DEFINE_LOG(BM8563)
 
@@ -17,7 +18,8 @@ BM8563::BM8563(I2CMaster* i2c, uint8_t Addr) : Addr(Addr){
 	}
 
 	// Clear status registers (0x0 and 0x1)
-	if(const auto ret = dev->write({ 0, 0, 0 }, 10); ret != ESP_OK){
+	constexpr std::array<uint8_t, 3> clear{ 0, 0, 0 };
+	if(const auto ret = dev->write(clear, 10); ret != ESP_OK){
 		CMF_LOG(BM8563, LogLevel::Error, "Error clearing status registers: %d", ret);
 		abort();
 	}

--- a/src/Devices/TCA9555.cpp
+++ b/src/Devices/TCA9555.cpp
@@ -3,6 +3,7 @@
 #include "Log/Log.h"
 #include "Periphery/I2CMaster.h"
 #include "Periphery/I2CDevice.h"
+#include <array>
 
 static inline uint8_t TCA_IT(uint8_t pin){ return (pin <= 7) ? 0 : 1; }
 
@@ -31,8 +32,10 @@ TCA9555::TCA9555(I2CMaster* i2c, uint8_t addr){
 }
 
 void TCA9555::reset(){
-	dev->write({ REG_DIR, 0xff, 0xff }); // All pins to input
-	dev->write({ REG_POLARITY, 0x00, 0x00 }); // Turn off polarity inversion for all pins
+	constexpr std::array<uint8_t, 3> dirReset{ REG_DIR, 0xff, 0xff };
+	constexpr std::array<uint8_t, 3> polarityReset{ REG_POLARITY, 0x00, 0x00 };
+	dev->write(dirReset); // All pins to input
+	dev->write(polarityReset); // Turn off polarity inversion for all pins
 	regs = Regs();
 }
 
@@ -65,7 +68,7 @@ bool TCA9555::read(uint8_t pin){
 }
 
 uint16_t TCA9555::readAll(){
-	std::vector<uint8_t> val(2);
+	std::array<uint8_t, 2> val{};
 	ESP_ERROR_CHECK(dev->write_read(REG_INPUT, val));
 	return (val[1] << 8) | val[0];
 }

--- a/src/Memory/ObjectMemory.h
+++ b/src/Memory/ObjectMemory.h
@@ -2,6 +2,7 @@
 #define CMF_OBJECTMEMORY_H
 
 #include <concepts>
+#include <span>
 #include "Cast.h"
 #include "Object/Object.h"
 #include "Memory/SmartPtr/StrongObjectPtr.h"
@@ -134,8 +135,8 @@ inline StrongObjectPtr<T> newObject(Object* owner = nullptr, Args&&... args) noe
  * @return The newly created object.
  */
 template<typename T, typename = std::enable_if<std::derived_from<T, Object>, T>::type>
-inline StrongObjectPtr<T> objectFromByteArray(const std::vector<uint8_t>& data, Object* owner = nullptr) noexcept {
-	OutArchive archive = data;
+inline StrongObjectPtr<T> objectFromByteArray(std::span<const uint8_t> data, Object* owner = nullptr) noexcept {
+	OutArchive archive(data);
 	uint64_t classID = 0;
 	archive << classID;
 
@@ -157,12 +158,12 @@ inline StrongObjectPtr<T> objectFromByteArray(const std::vector<uint8_t>& data, 
  * @return True if successful, false if given object is invalid or of wrong type
  */
 template<typename T, typename = std::enable_if<std::derived_from<T, Object>, T>::type>
-inline bool objectFromByteArray(T* object, const std::vector<uint8_t>& data) noexcept {
+inline bool objectFromByteArray(T* object, std::span<const uint8_t> data) noexcept {
 	if(!isValid(object)) {
 		return false;
 	}
 
-	OutArchive archive = data;
+	OutArchive archive(data);
 	uint64_t classID = 0;
 	archive << classID;
 

--- a/src/Misc/Enum.h
+++ b/src/Misc/Enum.h
@@ -4,7 +4,7 @@
 #include <concepts>
 #include <cstdio>
 #include <numeric>
-#include <vector>
+#include <span>
 
 template<typename T = int, typename = std::enable_if<std::integral<T>, T>::type>
 class Enum {
@@ -14,7 +14,7 @@ public:
 	template<typename E>
 	inline constexpr Enum(E val) noexcept : value(static_cast<T>(val)) {}
 
-	inline virtual constexpr std::vector<T> getValues() const noexcept{
+	inline virtual constexpr std::span<const T> getValues() const noexcept{
 		return {};
 	}
 
@@ -38,7 +38,10 @@ private:
 			__VA_ARGS__																												\
 		};                                        																					\
 																																	\
-		inline virtual constexpr std::vector<Type> getValues() const noexcept override { return {__VA_ARGS__}; } 					\
+		inline std::span<const Type> getValues() const noexcept override {                                                          \
+			static constexpr Type __cmfEnumValues[] = { __VA_ARGS__ };                                                              \
+			return std::span<const Type>(__cmfEnumValues);                                                                          \
+		}                                                                                                                           \
 	}
 
 #define DECLARE_CLASS_ENUM_STARTING_WITH(Name, Type, First, ...) 																	\
@@ -54,7 +57,10 @@ private:
 			__VA_ARGS__																												\
 		};                                        																					\
 																																	\
-		inline virtual constexpr std::vector<Type> getValues() const noexcept override { return {__VA_ARGS__}; } 					\
+		inline std::span<const Type> getValues() const noexcept override {                                                          \
+			static constexpr Type __cmfEnumValues[] = { __VA_ARGS__ };                                                              \
+			return std::span<const Type>(__cmfEnumValues);                                                                          \
+		}                                                                                                                           \
 	}
 
 #define DECLARE_ENUM(Name, ...) DECLARE_CLASS_ENUM(Name, int, __VA_ARGS__)

--- a/src/Periphery/I2CDevice.cpp
+++ b/src/Periphery/I2CDevice.cpp
@@ -10,7 +10,7 @@ I2CDevice::~I2CDevice(){
 	i2c_master_bus_rm_device(hndl);
 }
 
-esp_err_t I2CDevice::write(const std::vector<uint8_t>& data, TickType_t wait){
+esp_err_t I2CDevice::write(std::span<const uint8_t> data, TickType_t wait){
 	return write(data.data(), data.size(), wait);
 }
 
@@ -22,7 +22,7 @@ esp_err_t I2CDevice::write(const uint8_t* data, size_t size, TickType_t wait){
 	return master->write(*this, data, size, wait);
 }
 
-esp_err_t I2CDevice::read(std::vector<uint8_t>& data, TickType_t wait){
+esp_err_t I2CDevice::read(std::span<uint8_t> data, TickType_t wait){
 	return read(data.data(), data.size(), wait);
 }
 
@@ -34,15 +34,15 @@ esp_err_t I2CDevice::read(uint8_t* data, size_t size, TickType_t wait){
 	return master->read(*this, data, size, wait);
 }
 
-esp_err_t I2CDevice::write_read(const std::vector<uint8_t>& writeData, std::vector<uint8_t>& readData, TickType_t wait){
+esp_err_t I2CDevice::write_read(std::span<const uint8_t> writeData, std::span<uint8_t> readData, TickType_t wait){
 	return write_read(writeData.data(), writeData.size(), readData.data(), readData.size(), wait);
 }
 
-esp_err_t I2CDevice::write_read(uint8_t writeData, std::vector<uint8_t>& readData, TickType_t wait){
+esp_err_t I2CDevice::write_read(uint8_t writeData, std::span<uint8_t> readData, TickType_t wait){
 	return write_read(&writeData, 1, readData.data(), readData.size(), wait);
 }
 
-esp_err_t I2CDevice::write_read(const std::vector<uint8_t>& writeData, uint8_t& readData, TickType_t wait){
+esp_err_t I2CDevice::write_read(std::span<const uint8_t> writeData, uint8_t& readData, TickType_t wait){
 	return write_read(writeData.data(), writeData.size(), &readData, 1, wait);
 }
 
@@ -54,7 +54,7 @@ esp_err_t I2CDevice::write_read(const uint8_t* writeData, size_t writeSize, uint
 	return master->write_read(*this, writeData, writeSize, readData, readSize, wait);
 }
 
-esp_err_t I2CDevice::writeRegister(uint8_t reg, const std::vector<uint8_t>& data, TickType_t wait){
+esp_err_t I2CDevice::writeRegister(uint8_t reg, std::span<const uint8_t> data, TickType_t wait){
 	return writeRegister(reg, data.data(), data.size(), wait);
 }
 
@@ -66,7 +66,7 @@ esp_err_t I2CDevice::writeRegister(uint8_t reg, const uint8_t* data, size_t size
 	return master->writeRegister(*this, reg, data, size, wait);
 }
 
-esp_err_t I2CDevice::readRegister(uint8_t reg, std::vector<uint8_t>& data, TickType_t wait){
+esp_err_t I2CDevice::readRegister(uint8_t reg, std::span<uint8_t> data, TickType_t wait){
 	return readRegister(reg, data.data(), data.size(), wait);
 }
 

--- a/src/Periphery/I2CDevice.h
+++ b/src/Periphery/I2CDevice.h
@@ -3,7 +3,7 @@
 
 #include <driver/i2c_types.h>
 #include <freertos/FreeRTOS.h>
-#include <vector>
+#include <span>
 
 class I2CDevice {
 	friend class I2CMaster;
@@ -12,30 +12,25 @@ public:
 	explicit I2CDevice(class I2CMaster* master, i2c_master_dev_handle_t hndl);
 	virtual ~I2CDevice();
 
-	esp_err_t write(const std::vector<uint8_t>& data, TickType_t wait = portMAX_DELAY);
+	esp_err_t write(std::span<const uint8_t> data, TickType_t wait = portMAX_DELAY);
 	esp_err_t write(uint8_t data, TickType_t wait = portMAX_DELAY);
 	esp_err_t write(const uint8_t* data, size_t size, TickType_t wait = portMAX_DELAY);
 
-	esp_err_t read(std::vector<uint8_t>& data, TickType_t wait = portMAX_DELAY);
+	esp_err_t read(std::span<uint8_t> data, TickType_t wait = portMAX_DELAY);
 	esp_err_t read(uint8_t& data, TickType_t wait = portMAX_DELAY);
 	esp_err_t read(uint8_t* data, size_t size, TickType_t wait = portMAX_DELAY);
 
-	template<size_t Size>
-	esp_err_t read(std::array<uint8_t, Size>& data, TickType_t wait = portMAX_DELAY){
-		return read(data.data(), Size, wait);
-	}
-
-	esp_err_t write_read(const std::vector<uint8_t>& writeData, std::vector<uint8_t>& readData, TickType_t wait = portMAX_DELAY);
-	esp_err_t write_read(uint8_t writeData, std::vector<uint8_t>& readData, TickType_t wait = portMAX_DELAY);
-	esp_err_t write_read(const std::vector<uint8_t>& writeData, uint8_t& readData, TickType_t wait = portMAX_DELAY);
+	esp_err_t write_read(std::span<const uint8_t> writeData, std::span<uint8_t> readData, TickType_t wait = portMAX_DELAY);
+	esp_err_t write_read(uint8_t writeData, std::span<uint8_t> readData, TickType_t wait = portMAX_DELAY);
+	esp_err_t write_read(std::span<const uint8_t> writeData, uint8_t& readData, TickType_t wait = portMAX_DELAY);
 	esp_err_t write_read(uint8_t writeData, uint8_t& readData, TickType_t wait = portMAX_DELAY);
 	esp_err_t write_read(const uint8_t* writeData, size_t writeSize, uint8_t* readData, size_t readSize, TickType_t wait = portMAX_DELAY);
 
-	esp_err_t writeRegister(uint8_t reg, const std::vector<uint8_t>& data, TickType_t wait = portMAX_DELAY);
+	esp_err_t writeRegister(uint8_t reg, std::span<const uint8_t> data, TickType_t wait = portMAX_DELAY);
 	esp_err_t writeRegister(uint8_t reg, uint8_t data, TickType_t wait = portMAX_DELAY);
 	esp_err_t writeRegister(uint8_t reg, const uint8_t* data, size_t size, TickType_t wait = portMAX_DELAY);
 
-	esp_err_t readRegister(uint8_t reg, std::vector<uint8_t>& data, TickType_t wait = portMAX_DELAY);
+	esp_err_t readRegister(uint8_t reg, std::span<uint8_t> data, TickType_t wait = portMAX_DELAY);
 	esp_err_t readRegister(uint8_t reg, uint8_t& data, TickType_t wait = portMAX_DELAY);
 	esp_err_t readRegister(uint8_t reg, uint8_t* data, size_t size, TickType_t wait = portMAX_DELAY);
 

--- a/src/Services/Modules/ModuleDevices/RM_TempHumModule.cpp
+++ b/src/Services/Modules/ModuleDevices/RM_TempHumModule.cpp
@@ -27,7 +27,8 @@ uint8_t RM_TempHumModule::getHumidity() const{
 //TODO - separate this out to its own Device class for AHT20
 std::array<uint8_t, 6> RM_TempHumModule::readData(){
 	std::array<uint8_t, 6> data{};
-	i2c->write({ 0xAC, 0x33, 0x00 });
+	constexpr std::array<uint8_t, 3> trigger{ 0xAC, 0x33, 0x00 };
+	i2c->write(trigger);
 	delayMillis(80);
 	i2c->read(data);
 


### PR DESCRIPTION
## Summary

Sweep through the framework converting heap-allocating `std::vector<>` patterns to `std::array` (fixed-size) and `std::span` (flexible read-only view) where the change is safe and the allocation savings actually matter — that is, on hot paths (I2C transactions, deserialization, enum reflection) rather than one-time init.

Reflection-bound constructors (`GENERATED_BODY`-decorated drivers, LED/ButtonInput/Motors/Servos batch registration, RawCache/ArchiveCache path lists) were intentionally **left alone**: their allocations happen once at startup, and changing those signatures would break the `CONSTRUCTOR_PACK` tuple type plus any caller using brace-init `{ ... }` (which doesn't bind to `std::span` until C++26).

## Changes

### `I2CDevice` byte-buffer API → `std::span`
- `write`, `read`, `write_read`, `writeRegister`, `readRegister` now take `std::span<const uint8_t>` / `std::span<uint8_t>` instead of `const std::vector<uint8_t>&` / `std::vector<uint8_t>&`.
- The separate templated `read(std::array<uint8_t, N>&, ...)` overload is folded into the `std::span<uint8_t>` overload — arrays convert to spans implicitly, so callers passing arrays still work without a dedicated template.
- Pointer-based overloads (`uint8_t*, size_t`) are unchanged.

### Driver call-site cleanups
- `TCA9555::reset` and `BM8563` status-clear: brace-init `dev->write({...})` (which heap-allocated a temporary `std::vector`) replaced with `constexpr std::array`.
- `TCA9555::readAll`: local `std::vector<uint8_t> val(2)` → `std::array<uint8_t, 2>`. Called on every poll of the readAll path.
- `RM_TempHumModule::readData`: same brace-init → array cleanup for the trigger sequence.

### `Archive` byte-array constructors → `std::span`
- `Archive`, `InArchive`, `OutArchive` constructors that took `const std::vector<uint8_t>&` now take `std::span<const uint8_t>`. Both vector and array callers continue to work via implicit conversion. `std::queue` overloads are unchanged (`std::queue` has no contiguous storage so a span makes no sense there).

### `ObjectMemory` deserialization helpers → `std::span`
- Both `objectFromByteArray` template overloads take `std::span<const uint8_t>` instead of `const std::vector<uint8_t>&`.

### `Enum::getValues()` returns `std::span<const T>` over a static array
- The base virtual returns `std::span<const T>` instead of `std::vector<T>`.
- `DECLARE_CLASS_ENUM` / `DECLARE_CLASS_ENUM_STARTING_WITH` macros now generate a `static constexpr Type __cmfEnumValues[]` inside the override and return a span over it. The original macro heap-allocated a fresh `std::vector` from an initializer list on **every call** — now zero allocations.

## Test plan
- [x] Build CMF as a component of `examples/get-started/hello_world` against ESP-IDF v5.5.3, target esp32s3, with `CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD=y`. Build succeeds.
- [x] Rebuild with `CONFIG_CMF_MODULES=y` + `CONFIG_RM_TempHum=y` to exercise the touched module code. Build succeeds.
- [ ] Behavioural test on real hardware (not run here — no device attached).
