### PR TITLE
Defer screen transition to LVGL::tick (BUT-210)

### DIFF
--- a/src/LV_Interface/LVGL.cpp
+++ b/src/LV_Interface/LVGL.cpp
@@ -31,6 +31,12 @@ LVGL::LVGL(Display* display, std::function<lv_theme_t*(lv_disp_t*)> themeInit) :
 }
 
 void LVGL::tick(float deltaTime) noexcept{
+	// Apply any queued transition before running the current screen's loop or
+	// the LVGL timer handler. AsyncEntity guarantees scanEvents() has returned
+	// before tick() runs, so destroying currentScreen here can no longer
+	// invalidate an EventHandle still being iterated by its scan loop.
+	applyPendingScreen();
+
 	if(currentScreen && currentScreen->loaded){
 		currentScreen->loop();
 	}
@@ -64,9 +70,23 @@ void LVGL::resume(){
 }
 
 void LVGL::startScreen(std::function<std::unique_ptr<LVScreen>()> create, lv_screen_load_anim_t anim){
+	// Queue the transition; tick() applies it on the next iteration, after
+	// scanEvents() has returned. Last queued transition wins if startScreen is
+	// called multiple times before the next tick.
+	nextScreenCreate = std::move(create);
+	nextScreenAnim = anim;
+}
+
+void LVGL::applyPendingScreen(){
+	if(!nextScreenCreate) return;
+
+	auto create = std::move(nextScreenCreate);
+	const auto anim = nextScreenAnim;
+	nextScreenCreate = nullptr;
+
 	if(anim == LV_SCR_LOAD_ANIM_NONE){
 		stopScreen();
-	}else{
+	}else if(currentScreen){
 		currentScreen->stop();
 		currentScreen.release(); // Will get auto deleted by LVGL
 	}

--- a/src/LV_Interface/LVGL.h
+++ b/src/LV_Interface/LVGL.h
@@ -12,6 +12,13 @@ class LVGL : public AsyncEntity {
 public:
 	LVGL(Display* display, std::function<lv_theme_t*(lv_disp_t*)> themeInit = {});
 
+	/**
+	 * Queues a screen transition. The actual destruction of the current screen
+	 * and construction of the new one is deferred to the next tick(), so it is
+	 * safe to call from inside an EventHandle callback (which would otherwise
+	 * destroy the EventHandle's owning screen while still iterating its scan
+	 * queue) or from an LVGL timer/animation callback.
+	 */
 	void startScreen(std::function<std::unique_ptr<LVScreen>()> create, lv_screen_load_anim_t anim = LV_SCR_LOAD_ANIM_NONE);
 
 	/** startScreen should be called immediately after this function. */
@@ -40,6 +47,11 @@ private:
 	static void flush(lv_display_t* disp, const lv_area_t* area, uint8_t* px_map);
 
 	std::unique_ptr<LVScreen> currentScreen;
+
+	std::function<std::unique_ptr<LVScreen>()> nextScreenCreate;
+	lv_screen_load_anim_t nextScreenAnim = LV_SCR_LOAD_ANIM_NONE;
+
+	void applyPendingScreen();
 
 	SemaphoreHandle_t initSem;
 };


### PR DESCRIPTION
startScreen() now queues the requested screen and the destroy+create work happens in tick(), after AsyncEntity::tickHandle has returned from scanEvents(). This makes it safe to call transition()/startScreen() from an EventHandle callback or an LVGL timer/animation callback without the caller's screen being destroyed mid-iteration of the scan/timer loop.