### PR TITLE
LEDBase: delete LEDFunction instances when overwritten or erased (CMF-65)

### DIFF
--- a/src/Services/LED/LED.h
+++ b/src/Services/LED/LED.h
@@ -119,9 +119,11 @@ public:
 		prevStates[led] = DataT(); //zero-value
 
 		if(currentFunctions.contains(led)){
+			destroyFunction(currentFunctions[led].function);
 			currentFunctions.erase(led);
 		}
 		if(prevFunctions.contains(led)){
+			destroyFunction(prevFunctions[led].function);
 			prevFunctions.erase(led);
 		}
 
@@ -145,9 +147,11 @@ public:
 		prevStates[led] = level;
 
 		if(currentFunctions.contains(led)){
+			destroyFunction(currentFunctions[led].function);
 			currentFunctions.erase(led);
 		}
 		if(prevFunctions.contains(led)){
+			destroyFunction(prevFunctions[led].function);
 			prevFunctions.erase(led);
 		}
 
@@ -175,7 +179,12 @@ public:
 		if(currentFunctions.contains(led)){
 			alreadyLocked = true;
 			if(!currentFunctions[led].isTemporary){
+				if(prevFunctions.contains(led)){
+					destroyFunction(prevFunctions[led].function);
+				}
 				prevFunctions[led] = std::move(currentFunctions[led]);
+			}else{
+				destroyFunction(currentFunctions[led].function);
 			}
 		}
 
@@ -252,6 +261,8 @@ public:
 
 			xSemaphoreGive(waitSemaphores[led]);
 
+			destroyFunction(func.function);
+
 			if(prevFunctions.contains(led)){
 				currentFunctions[led].function = std::move(prevFunctions[led].function);
 				currentFunctions[led].isTemporary = prevFunctions[led].isTemporary;
@@ -321,6 +332,12 @@ private:
 			if(!pin.driver) continue;
 
 			pin.driver->write(pin.port, false);
+		}
+	}
+
+	void destroyFunction(StrongObjectPtr<LEDFunction<LED, DataT>>& function) noexcept{
+		if(function.isValid()){
+			delete *function;
 		}
 	}
 


### PR DESCRIPTION
## Summary

`LEDBase` stores its registered `LEDFunction`s in `currentFunctions` /
`prevFunctions` maps via `StrongObjectPtr`. `StrongObjectPtr` destruction
only drops the reference count in `ObjectManager` — it does **not** call
`delete` on the underlying `Object`. So every site where a slot's
`function` was overwritten or its map entry was erased was leaking the
`LEDFunction` (memory only freed when the owning `LEDBase` itself
eventually died and `Object::~Object` cascaded `delete` to children).

This PR adds the missing `delete` calls. Pattern matches the
established style in `Object.cpp:22` (`delete *child;`) and
`StateMachine.cpp:58` (`delete *current;`): `isValid()` check then
`delete *strongPtr`. Wrapped in a private member helper
`destroyFunction()` since the call repeats 6 times.

## Sites covered

- `off()` and `on()` — before erasing `currentFunctions[led]` and
  `prevFunctions[led]`.
- `set()`:
  - When the existing current is non-temp and a previous `prevFunctions[led]`
    is already present, destroy the old prev before the move-assign from
    current overwrites it.
  - When the existing current is temp (so the prev-move is skipped), destroy
    the temp current before `currentFunctions[led] = move(regFunc)`
    overwrites it.
- `tick()` — when a function reports `isDone()`, destroy it once at the top
  of the done-handling block. Covers all three branches (prev exists,
  prevStates exists, full erase) without repeating the call.

## Why `~LEDBase()` is untouched

`set()` does `function->setOwner(this)`, so live `LEDFunction`s are children
of the owning `LEDBase`. `Object::~Object` (`src/Object/Object.cpp:14-28`)
already iterates `childrenObjects` and `delete *child`s each one. Anything
still in the maps at destruction time gets cleaned up via that path.

## Test plan

- [ ] Visual review of `src/Services/LED/LED.h` diff.
- [ ] Verify the change builds in a consuming project (CMF has no main app
      of its own to build directly).
- [ ] Sanity-check on hardware: set/replace LED functions in quick
      succession (temp-over-non-temp, non-temp-over-temp, off/on while a
      function is active) and confirm heap usage is stable.
