### PR TITLE
Reworked FileSystem for streaming decompressed archives

### DIFF
--- a/src/FileSystem/ArchiveCache.cpp
+++ b/src/FileSystem/ArchiveCache.cpp
@@ -1,11 +1,8 @@
 #include "ArchiveCache.h"
 #include <vector>
+#include <esp_heap_caps.h>
 #include "Log/Log.h"
 #include "FileSystem/RamFile.h"
-
-extern "C" {
-#include <heatshrink_decoder.h>
-}
 
 DEFINE_LOG(ArchiveCache)
 
@@ -16,8 +13,12 @@ ArchiveCache::ArchiveCache(const File& file) : archiveFile(file){
 	ArchiveCache::load();
 }
 
+ArchiveCache::ArchiveCache(const bool useExternalRam) : useExternalRam(useExternalRam){}
+
 ArchiveCache::~ArchiveCache(){
-	free(data);
+	if(ownsData){
+		free(data);
+	}
 	data = nullptr;
 }
 
@@ -28,61 +29,95 @@ void ArchiveCache::setArchiveFile(const File& file){
 	archiveFile = file;
 }
 
+void ArchiveCache::setBuffer(uint8_t* buffer, const size_t bufferCapacity){
+	data = buffer;
+	capacity = bufferCapacity;
+	ownsData = false;
+}
+
 void ArchiveCache::load(){
 	if(loaded) return;
+
+	if(!archiveFile){
+		CMF_LOG(ArchiveCache, LogLevel::Error, "No archive file to load");
+		return;
+	}
+
 	loaded = true;
+
+	// Reads exactly n bytes or reports failure (short read / closed source -> (size_t)-1).
+	auto readExact = [&](void* dst, const size_t n) {
+		return archiveFile.read((uint8_t*)dst, n) == n;
+	};
+
+	// A corrupt/truncated archive is a build- or flash-time fault, not a recoverable runtime
+	// condition: fail loudly rather than silently serving stale shared-buffer bytes.
+	auto fail = [&](const char* why) {
+		CMF_LOG(ArchiveCache, LogLevel::Error, "Corrupt archive: %s", why);
+		abort();
+	};
 
 	archiveFile.seek(0);
 	uint32_t count = 0;
-	archiveFile.read((uint8_t*)&count, 4);
+	if(!readExact(&count, 4)) return fail("truncated header");
 
 	std::vector<Entry> tmp;
 	tmp.reserve(count);
 
 	size_t totalSize = 0;
 
-	while(archiveFile.available()){
+	for(uint32_t i = 0; i < count; i++){
 		std::string name;
 		name.reserve(32);
-		while(archiveFile.available()){
-			if(name.length() >= 32){
-				CMF_LOG(ArchiveCache, LogLevel::Error, "Too big filename; %s...", name.c_str());
-				abort();
-			}
-
-			char c = 0;
-			archiveFile.read((uint8_t*)&c, 1);
-			if(c == 0) break;
-
+		char c = 0;
+		while(archiveFile.read((uint8_t*)&c, 1) == 1 && c != 0){
+			if(name.length() >= 32) return fail("filename too long");
 			name.append(1, c);
 		}
 
-		if(name.empty()) break;
-
 		size_t size = 0;
-		archiveFile.read((uint8_t*)&size, 4);
+		if(!readExact(&size, 4)) return fail("truncated directory");
 		totalSize += size;
 
 		tmp.emplace_back(Entry{ name, size, 0 });
 	}
 
-	data = (uint8_t*)malloc(totalSize);
+	char terminator = 0;
+	if(!readExact(&terminator, 1)) return fail("missing directory terminator");
 
-	if(data == nullptr){
-		CMF_LOG(ArchiveCache, LogLevel::Warning, "Failed allocating data buffer of %zu B", totalSize);
+	if(ownsData){
+		// No shared buffer was provided: allocate one sized exactly to this archive.
+		data = (uint8_t*)(useExternalRam ? heap_caps_malloc(totalSize, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) : malloc(totalSize));
+		if(data == nullptr){
+			CMF_LOG(ArchiveCache, LogLevel::Warning, "Failed allocating data buffer of %zu B", totalSize);
+			loaded = false;
+			return;
+		}
+		capacity = totalSize;
+	}else if(data == nullptr){
+		CMF_LOG(ArchiveCache, LogLevel::Error, "No buffer set for archive load");
+		loaded = false;
+		return;
+	}else if(totalSize > capacity){
+		CMF_LOG(ArchiveCache, LogLevel::Error, "Archive (%zu B) exceeds shared buffer (%zu B)", totalSize, capacity);
+		loaded = false;
 		return;
 	}
 
 	size_t offset = 0;
 
 	for(auto& entry : tmp){
-		archiveFile.read(data + offset, entry.size);
+		if(archiveFile.read(data + offset, entry.size) != entry.size){
+			return fail("truncated payload");
+		}
 		entry.offset = offset;
 
 		offset += entry.size;
 
 		entries.insert(std::make_pair(entry.name, std::move(entry)));
 	}
+
+	archiveFile = File();
 }
 
 void ArchiveCache::unload(){
@@ -90,8 +125,12 @@ void ArchiveCache::unload(){
 	loaded = false;
 
 	entries.clear();
-	free(data);
-	data = nullptr;
+	if(ownsData){
+		// Shared buffers are kept for reuse; only free a buffer we allocated ourselves.
+		free(data);
+		data = nullptr;
+	}
+	archiveFile = File();
 }
 
 File ArchiveCache::open(const char* path){

--- a/src/FileSystem/ArchiveCache.h
+++ b/src/FileSystem/ArchiveCache.h
@@ -8,7 +8,16 @@
 
 class ArchiveCache : public FileCache {
 public:
+	/**
+	 * @brief Construct and immediately load from the given archive file.
+	 */
 	ArchiveCache(const File& file);
+
+	/**
+	 * @brief Construct without an archive file; load is deferred until setArchiveFile() + load().
+	 * @param useExternalRam Allocate the decompressed archive buffer in SPIRAM.
+	 */
+	explicit ArchiveCache(bool useExternalRam = false);
 	~ArchiveCache() override;
 
 	void load() override;
@@ -17,6 +26,14 @@ public:
 	File open(const char* path) override;
 
 	void setArchiveFile(const File& file);
+
+	/**
+	 * @brief Decompress into a caller-owned buffer instead of allocating one per load.
+	 *        Lets several caches share a single, permanently reserved buffer.
+	 * @param buffer   Destination buffer
+	 * @param capacity Buffer size in bytes
+	 */
+	void setBuffer(uint8_t* buffer, size_t capacity);
 
 private:
 	struct Entry {
@@ -28,7 +45,10 @@ private:
 	std::unordered_map<std::string, const Entry> entries;
 
 	bool loaded = false;
+	bool useExternalRam = false;
 	uint8_t* data = nullptr;
+	size_t capacity = 0;
+	bool ownsData = true; // false when `data` is a caller-provided shared buffer
 	File archiveFile;
 };
 

--- a/src/FileSystem/CompressedFile.cpp
+++ b/src/FileSystem/CompressedFile.cpp
@@ -2,128 +2,181 @@
 
 #include "Log/Log.h"
 #include <cstring>
-#include <esp_heap_caps.h>
-
-extern "C" {
-#include <heatshrink_decoder.h>
-}
+#include <algorithm>
 
 DEFINE_LOG(CompressedFile)
 
 static constexpr uint8_t HEATSHRINK_WINDOW_SZ2 = 14;
 static constexpr uint8_t HEATSHRINK_LOOKAHEAD_SZ2 = 7;
-static constexpr uint16_t HEATSHRINK_INPUT_BUF_SIZE = 256;
-static constexpr size_t HEATSHRINK_POLL_BUF_SIZE = 1024;
 
-void CompressedFile::decompress(const uint8_t* compressedData, size_t compressedSize, bool use32bAligned){
-	heatshrink_decoder* hsd = heatshrink_decoder_alloc(HEATSHRINK_INPUT_BUF_SIZE, HEATSHRINK_WINDOW_SZ2, HEATSHRINK_LOOKAHEAD_SZ2);
-	if(!hsd){
+CompressedFile::CompressedFile(File source) : source(source), filePath(source ? source.name() : ""){
+	if(!source){
+		CMF_LOG(CompressedFile, LogLevel::Error, "Couldn't open source file: %s", source.name());
+		return;
+	}
+
+	hsd = heatshrink_decoder_alloc(InputBufSize, HEATSHRINK_WINDOW_SZ2, HEATSHRINK_LOOKAHEAD_SZ2);
+	if(hsd == nullptr){
 		CMF_LOG(CompressedFile, LogLevel::Error, "Failed to allocate heatshrink decoder");
 		return;
 	}
 
-	uint8_t pollBuf[HEATSHRINK_POLL_BUF_SIZE];
-
-	auto pollAll = [&]() {
-		HSD_poll_res pres;
-		do{
-			size_t polled = 0;
-			pres = heatshrink_decoder_poll(hsd, pollBuf, HEATSHRINK_POLL_BUF_SIZE, &polled);
-			result.insert(result.end(), pollBuf, pollBuf + polled);
-		} while(pres == HSDR_POLL_MORE);
-	};
-
-	size_t inOffset = 0;
-	while(inOffset < compressedSize){
-		size_t sunk = 0;
-		heatshrink_decoder_sink(hsd, const_cast<uint8_t*>(compressedData + inOffset), compressedSize - inOffset, &sunk);
-		inOffset += sunk;
-		pollAll();
-	}
-
-	HSD_finish_res fres = heatshrink_decoder_finish(hsd);
-	while(fres == HSDR_FINISH_MORE){
-		pollAll();
-		fres = heatshrink_decoder_finish(hsd);
-	}
-
-	heatshrink_decoder_free(hsd);
-}
-
-CompressedFile::CompressedFile(File file, size_t reserveSize, bool use32bAligned) : filePath(file.name()){
-	if(!file){
-		CMF_LOG(CompressedFile, LogLevel::Error, "Couldn't open file: %s", file.name());
-		return;
-	}
-	result.reserve(reserveSize);
-
-	file.seek(0);
-	const size_t compressedSize = file.size();
-
-	if(compressedSize == 0){
-		CMF_LOG(CompressedFile, LogLevel::Error, "File is empty: %s", file.name());
-		file.close();
-		return;
-	}
-
-	auto* compressedData = static_cast<uint8_t*>(malloc(compressedSize));
-	if(!compressedData){
-		CMF_LOG(CompressedFile, LogLevel::Error, "Couldn't allocate %zu B to read compressed file: %s", compressedSize, file.name());
-		file.close();
-		return;
-	}
-
-	file.read(compressedData, compressedSize);
-	decompress(compressedData, compressedSize, use32bAligned);
-	free(compressedData);
-
-	if(result.empty()){
-		CMF_LOG(CompressedFile, LogLevel::Error, "Decompression failed for: %s", file.name());
-	}
-}
-
-CompressedFile::CompressedFile(const uint8_t* compressedData, size_t compressedSize, const char* name, size_t reserveSize, bool use32bAligned) : filePath(name){
-	result.reserve(reserveSize);
-	decompress(compressedData, compressedSize, use32bAligned);
-	if(result.empty()){
-		CMF_LOG(CompressedFile, LogLevel::Error, "Decompression failed for: %s", name);
-	}
+	source.seek(0, SeekMode::SeekSet);
 }
 
 CompressedFile::~CompressedFile(){
+	if(hsd != nullptr){
+		heatshrink_decoder_free(hsd);
+		hsd = nullptr;
+	}
+}
+
+File CompressedFile::open(const File& source){
+	return { std::make_shared<CompressedFile>(source) };
 }
 
 CompressedFile::operator bool(){
-	return !result.empty();
-}
-
-File CompressedFile::open(const File& file, size_t reserveSize, bool use32bAligned){
-	std::shared_ptr<CompressedFile> f = std::make_shared<CompressedFile>(file, reserveSize, use32bAligned);
-	return { f };
+	return hsd != nullptr && source;
 }
 
 void CompressedFile::close(){
-	result.clear();
+	source.close();
 	filePath = "";
 }
 
+void CompressedFile::resetStream(){
+	if(hsd != nullptr){
+		heatshrink_decoder_reset(hsd);
+	}
+	source.seek(0, SeekMode::SeekSet);
+	inPos = inLen = 0;
+	outPos = outLen = 0;
+	finished = false;
+	decodeError = false;
+	cursor = 0;
+}
+
+// Pulls the next chunk of decompressed bytes into outBuf.
+// Returns false once the stream is fully drained.
+bool CompressedFile::fillOut(){
+	if(outPos < outLen) return true;
+	outPos = outLen = 0;
+
+	if(hsd == nullptr) return false;
+
+	while(true){
+		// Drain any output the decoder already has.
+		size_t polled = 0;
+		HSD_poll_res pres = heatshrink_decoder_poll(hsd, outBuf, OutputBufSize, &polled);
+		if(pres < 0){ // HSDR_POLL_ERROR_*
+			CMF_LOG(CompressedFile, LogLevel::Error, "Decode poll error (%d): %s", pres, filePath.c_str());
+			decodeError = finished = true;
+			return false;
+		}
+		if(polled > 0){
+			outLen = polled;
+			outPos = 0;
+			return true;
+		}
+		if(pres == HSDR_POLL_MORE) continue; // more output pending; poll again
+
+		// No output: feed the decoder. Refill our input buffer from the source if drained.
+		if(inPos >= inLen){
+			const size_t got = source.read(inBuf, InputBufSize);
+			inLen = (got == (size_t)-1) ? 0 : got; // a closed/failed source reads as EOF, not a huge length
+			inPos = 0;
+		}
+
+		if(inPos < inLen){
+			size_t sunk = 0;
+			HSD_sink_res sres = heatshrink_decoder_sink(hsd, inBuf + inPos, inLen - inPos, &sunk);
+			if(sres < 0){ // HSDR_SINK_ERROR_*
+				CMF_LOG(CompressedFile, LogLevel::Error, "Decode sink error (%d): %s", sres, filePath.c_str());
+				decodeError = finished = true;
+				return false;
+			}
+			inPos += sunk;
+			continue; // loop back to poll the freshly sunk data
+		}
+
+		// Source exhausted: tell the decoder, then poll out the tail.
+		if(finished) return false;
+		HSD_finish_res fres = heatshrink_decoder_finish(hsd);
+		if(fres == HSDR_FINISH_MORE) continue; // tail output remains; poll it on next loop
+		if(fres < 0){ // HSDR_FINISH_ERROR_*
+			CMF_LOG(CompressedFile, LogLevel::Error, "Decode finish error (%d): %s", fres, filePath.c_str());
+			decodeError = true;
+		}
+		finished = true;
+		return false;
+	}
+}
+
+size_t CompressedFile::read(uint8_t* dest, size_t len){
+	size_t written = 0;
+	while(written < len){
+		if(outPos >= outLen && !fillOut()) break;
+
+		const size_t n = std::min(len - written, outLen - outPos);
+		memcpy(dest + written, outBuf + outPos, n);
+		outPos += n;
+		written += n;
+		cursor += n;
+	}
+	return written;
+}
+
+bool CompressedFile::seek(int pos, int whence){
+	int64_t target;
+	if(whence == SEEK_SET){
+		target = pos;
+	}else if(whence == SEEK_CUR){
+		target = (int64_t)cursor + pos;
+	}else{
+		CMF_LOG(CompressedFile, LogLevel::Warning, "SEEK_END unsupported on compressed stream: %s", filePath.c_str());
+		return false;
+	}
+
+	if(target < 0){
+		CMF_LOG(CompressedFile, LogLevel::Warning, "Seek before start (%lld) on %s", target, filePath.c_str());
+		return false;
+	}
+
+	const size_t tgt = (size_t)target;
+	if(tgt == cursor) return true;
+
+	if(tgt < cursor){
+		const size_t back = cursor - tgt;
+		if(back <= outPos){
+			// Within the still-resident output window: rewind without re-decoding.
+			outPos -= back;
+			cursor = tgt;
+			return true;
+		}
+		resetStream(); // beyond the buffered window — can only go back by restarting the decode
+	}
+
+	// Skip forward by decoding and discarding.
+	uint8_t scratch[InputBufSize];
+	while(cursor < tgt){
+		const size_t want = std::min(sizeof(scratch), tgt - cursor);
+		if(read(scratch, want) != want) return false; // reached end before target
+	}
+	return true;
+}
+
 size_t CompressedFile::size() const{
-	return result.size();
+	// NOTE: forward-only stream. The total decompressed size is NOT known without decoding the
+	// whole stream, so this returns bytes decoded so far not the full length.
+	return cursor;
 }
 
 const char* CompressedFile::name() const{
 	return filePath.c_str();
 }
 
-size_t IRAM_ATTR CompressedFile::read(uint8_t* dest, size_t len){
-	if(cursor >= result.size()) return 0;
-	len = std::min(len, result.size() - cursor);
-	if(len <= 0) return 0;
-
-	memcpy(dest, result.data() + cursor, len);
-	cursor += len;
-
-	return len;
+size_t CompressedFile::pos() const{
+	return cursor;
 }
 
 size_t CompressedFile::write(const uint8_t* buf, size_t size){
@@ -131,19 +184,4 @@ size_t CompressedFile::write(const uint8_t* buf, size_t size){
 }
 
 void CompressedFile::flush(){
-}
-
-bool CompressedFile::seek(int pos, int whence){
-	if(whence == SEEK_SET){
-		cursor = pos;
-	} else if(whence == SEEK_CUR){
-		cursor += pos;
-	} else if(whence == SEEK_END){
-		cursor = result.size() - pos;
-	}
-	return true;
-}
-
-size_t CompressedFile::pos() const{
-	return cursor;
 }

--- a/src/FileSystem/CompressedFile.h
+++ b/src/FileSystem/CompressedFile.h
@@ -2,25 +2,35 @@
 #define BUTTERBOTCTRL_FIRMWARE_COMPRESSEDFILE_H
 
 #include <cstdint>
-#include <vector>
 #include <string>
 #include "FileImpl.h"
 #include "File.h"
 
+extern "C" {
+#include <heatshrink_decoder.h>
+}
+
+/**
+ * @brief A forward-streaming heatshrink decompressor exposed as a File.
+ *
+ * Wraps a compressed source File and decodes it on demand as read() is called, holding only a
+ * small decoder window + I/O buffers (never the whole decompressed archive). This keeps the
+ * decompression concern entirely inside this class: consumers such as ArchiveCache read through
+ * the plain File interface and don't know (or care) whether the bytes are compressed.
+ *
+ * Reads are sequential; seek() supports rewinding (cheap within the current output buffer, otherwise
+ * re-decodes from the start) and forward skips. This is NOT a random-access/sized File: size() reports
+ * bytes decoded so far (not the total length), so available() is always 0 — read it to completion
+ * rather than wrapping it in something that pre-allocates from size() (e.g. RamFile).
+ */
 class CompressedFile : public FileImpl {
 public:
-	/**
-	 * @param file input compressed File object
-	 * @param reserveSize size to reserve for internal buffer, in bytes
-	 * @param use32bAligned if memory is organized in 32bit alignment
-	 */
-	CompressedFile(File file, size_t reserveSize = 0, bool use32bAligned = false);
-	CompressedFile(const uint8_t* compressedData, size_t compressedSize, const char* name, size_t reserveSize = 0, bool use32bAligned = false);
+	explicit CompressedFile(File source);
 	~CompressedFile() override;
 
 	operator bool() override;
 
-	static File open(const File& file, size_t reserveSize = 0, bool use32bAligned = false);
+	static File open(const File& source);
 	void close() override;
 
 	size_t size() const override;
@@ -34,11 +44,29 @@ public:
 	size_t pos() const override;
 
 private:
-	void decompress(const uint8_t* compressedData, size_t compressedSize, bool use32bAligned);
+	static constexpr size_t InputBufSize = 256;
+	static constexpr size_t OutputBufSize = 1024;
 
-	std::vector<uint8_t> result;
-	size_t cursor = 0;
+	File source;
+	heatshrink_decoder* hsd = nullptr;
 	std::string filePath;
+
+	uint8_t inBuf[InputBufSize];
+	size_t inPos = 0, inLen = 0;  // compressed bytes pending sink
+
+	uint8_t outBuf[OutputBufSize];
+	size_t outPos = 0, outLen = 0; // decoded bytes pending consumption
+
+	// Is decoder done
+	bool finished = false;
+	// Decoder reported an error (HSDR_*_ERROR_*); the stream is truncated/garbage
+	bool decodeError = false;
+	// Position in stream
+	size_t cursor = 0;
+
+	void resetStream();
+	// Refill outBuf with decoded bytes; false at end of stream
+	bool fillOut();
 };
 
 #endif //BUTTERBOTCTRL_FIRMWARE_COMPRESSEDFILE_H

--- a/src/LV_Interface/LVGIF.cpp
+++ b/src/LV_Interface/LVGIF.cpp
@@ -79,7 +79,7 @@ LVGIF::~LVGIF(){
 	if(timer != nullptr){
 		lv_timer_del(timer);
 	}
-	delete imgPath;
+	delete[] imgPath;
 }
 
 void LVGIF::start(){

--- a/src/LV_Interface/LVGIF.cpp
+++ b/src/LV_Interface/LVGIF.cpp
@@ -6,40 +6,39 @@
 DEFINE_LOG(LVGIF)
 
 LVGIF::LVGIF(lv_obj_t* parent, const char* path) : LVObject(parent), path(path){
-	auto strpath = std::string(path);
-	if(strpath.find("S:") == 0){
-		strpath = strpath.substr(2);
-	}
-	auto descPath = "/spiffs" + strpath + "/desc.bin";
+	const std::string descPath = std::string(path) + "/desc.bin";
 
-	pathLen = descPath.length() + 10;
+	pathLen = descPath.length() + 12;
 	imgPath = new char[pathLen];
-	auto f = fopen(descPath.c_str(), "r");
 
-	if(f == nullptr){
+	lv_fs_file_t f;
+	if(lv_fs_open(&f, descPath.c_str(), LV_FS_MODE_RD) != LV_FS_RES_OK){
 		CMF_LOG(LVGIF, LogLevel::Error, "Couldn't open GIF descriptor file at %s", descPath.c_str());
 		return;
 	}
 
-	//read w and h as uint16_t variables, most significant byte is read first
-	fread(((uint8_t*) &w) + 1, 1, 1, f);
-	fread(((uint8_t*) &w), 1, 1, f);
-	fread(((uint8_t*) &h) + 1, 1, 1, f);
-	fread(((uint8_t*) &h), 1, 1, f);
-	uint32_t length;
-	fread(((uint8_t*) &length) + 3, 1, 1, f);
-	fread(((uint8_t*) &length) + 2, 1, 1, f);
-	fread(((uint8_t*) &length) + 1, 1, 1, f);
-	fread(((uint8_t*) &length), 1, 1, f);
-	durations.reserve(length);
-	for(int i = 0; i < length; i++){
-		uint16_t duration;
-		fread(((uint8_t*) &duration) + 1, 1, 1, f);
-		fread(((uint8_t*) &duration), 1, 1, f);
-		durations.push_back(duration * 10);
+	// Header: width(2) + height(2) + frame count(4), all big-endian (most significant byte first)
+	uint8_t header[8];
+	uint32_t br = 0;
+	lv_fs_read(&f, header, sizeof(header), &br);
+	if(br < sizeof(header)){
+		CMF_LOG(LVGIF, LogLevel::Error, "GIF descriptor too short at %s", descPath.c_str());
+		lv_fs_close(&f);
+		return;
 	}
 
-	fclose(f);
+	w = (header[0] << 8) | header[1];
+	h = (header[2] << 8) | header[3];
+	const uint32_t length = ((uint32_t) header[4] << 24) | ((uint32_t) header[5] << 16) | ((uint32_t) header[6] << 8) | header[7];
+
+	durations.reserve(length);
+	for(uint32_t i = 0; i < length; i++){
+		uint8_t duration[2]; // big-endian, in 10ms units
+		lv_fs_read(&f, duration, sizeof(duration), &br);
+		durations.push_back(((duration[0] << 8) | duration[1]) * 10);
+	}
+
+	lv_fs_close(&f);
 
 	lv_obj_set_size(obj, w, h);
 	lv_obj_set_style_bg_opa(obj, LV_OPA_TRANSP, 0);
@@ -77,7 +76,9 @@ LVGIF::LVGIF(lv_obj_t* parent, const char* path) : LVObject(parent), path(path){
 }
 
 LVGIF::~LVGIF(){
-	lv_timer_del(timer);
+	if(timer != nullptr){
+		lv_timer_del(timer);
+	}
 	delete imgPath;
 }
 

--- a/src/LV_Interface/LVGIF.h
+++ b/src/LV_Interface/LVGIF.h
@@ -27,8 +27,8 @@ public:
 	[[nodiscard]] size_t getNumFrames() const;
 
 private:
-	lv_obj_t* img;
-	lv_timer_t* timer;
+	lv_obj_t* img = nullptr;
+	lv_timer_t* timer = nullptr;
 
 	uint16_t w = 0, h = 0;
 	std::vector<uint16_t> durations; //in ms


### PR DESCRIPTION
CompressedFile:
  - Decode heatshrink on demand via read() instead of buffering the whole
    archive; hold only the decoder window + small I/O buffers.
  - Surface decoder errors (poll/sink/finish) instead of treating them as EOF.
  - seek(): reject negative/out-of-range targets, return false on short seeks,
    and rewind cheaply within the resident output buffer.
  - Document the forward-only contract (size() is bytes-so-far, not total).

ArchiveCache:
  - Support a caller-provided shared buffer (setBuffer) so caches reuse one
    pre-reserved SPIRAM buffer instead of allocating per load.
  - Validate every read during load and abort() on a corrupt/truncated archive
    rather than silently serving stale buffer bytes.
  - Only free self-allocated buffers; keep shared buffers across unload().